### PR TITLE
feat(env): rich environment v1 — toroidal world, occlusion, physics, hazards, GDI, JEPA, DOF coupling

### DIFF
--- a/.agents/handoff-latest-20260301-1827-orchestrator-z4r8.json
+++ b/.agents/handoff-latest-20260301-1827-orchestrator-z4r8.json
@@ -1,0 +1,107 @@
+{
+  "session_id": "20260301-1827-orchestrator-z4r8",
+  "parent_session_id": "20260301-1100-orchestrator-z4r8",
+  "agent_role": "orchestrator",
+  "timestamp_utc": "2026-03-01T18:27:13Z",
+  "state": "HANDOFF_READY",
+  "goal": "Advance shared-environment convergence with capability guardrails while preserving transfer and keep release continuity intact.",
+  "in_scope": [
+    "Add capability guardrail controls to coevolution training",
+    "Run long CUDA shared-world retrains and calibrated cross-evals",
+    "Generate storyboard GIF evidence for regression/survival tradeoffs",
+    "Publish v0.1.0 tag/release with latest model artifacts"
+  ],
+  "out_of_scope": [
+    "Pi 5 physical hardware validation",
+    "SMBus2 live hardware loop execution"
+  ],
+  "constraints": [
+    "Use cross-eval artifacts (not train fitness) for promotion decisions",
+    "Keep anonymous-channel adaptation and cross-embodiment transfer priorities",
+    "No physical-device assumptions"
+  ],
+  "changes": [
+    {
+      "file": "src/ai_embedded_dynamic_diversity/train/cli.py",
+      "reason": "Added capability guardrail proxy/penalty path and CLI controls for coevolution selection."
+    },
+    {
+      "file": "tests/test_train_transfer.py",
+      "reason": "Added guardrail penalty unit coverage."
+    },
+    {
+      "file": "IMPLEMENTED.md",
+      "reason": "Captured v03/v04/v05 convergence outcomes and artifact references."
+    },
+    {
+      "file": "TODO.md",
+      "reason": "Added next tasks for proxy calibration and transfer recovery under guardrails."
+    },
+    {
+      "file": "skills/dynamic-diversity-research/references/session-lessons-latest.md",
+      "reason": "Recorded reusable lessons and handoff continuation priorities."
+    }
+  ],
+  "validation": {
+    "commands": [
+      ".venv\\Scripts\\python.exe -m pytest -q tests/test_train_transfer.py",
+      ".venv\\Scripts\\python.exe -m ai_embedded_dynamic_diversity.train.cross_eval_cli --checkpoints-list \"artifacts/model-core-coevo-guardrail-shared-extreme-v05.pt,artifacts/model-core-coevo-guardrail-shared-extreme-v04.pt,artifacts/model-core-coevo-1200-shared-extreme-v02.pt,artifacts/model-core-champion-v07.pt,artifacts/model-core-champion-v09.pt\" ...",
+      "gh release view v0.1.0 --json tagName,name,url,assets"
+    ],
+    "key_results": [
+      "Guardrail v05 completed full 1200 generations (records=1200).",
+      "Guardrail line improved capability over v02 but still trails in weighted transfer.",
+      "v0.1.0 tag and release published with model checkpoint and metrics assets."
+    ],
+    "artifacts": [
+      "artifacts/model-core-coevo-guardrail-shared-extreme-v05.pt",
+      "artifacts/model-core-coevo-guardrail-shared-extreme-v05.metrics.json",
+      "artifacts/cross-eval-guardrail-v05-v04-v02-v07-v09-calib-extreme-r3.json",
+      "artifacts/cross-eval-guardrail-v05-v04-v02-v07-v09-calib-extreme-r3.md",
+      "artifacts/viz-storyboard-v04-v02-calib-large-v1/convergence-storyboard.gif",
+      "artifacts/viz-storyboard-v07-v03-calib-large-v1/convergence-storyboard.gif"
+    ]
+  },
+  "risks": [
+    "Training-time guardrail proxies are not yet tightly calibrated to cross-eval capability metrics.",
+    "Transfer-capability tradeoff remains unresolved under current penalty weights."
+  ],
+  "assumptions": [
+    "Champion promotion remains blocked until cross-eval rank surpasses v07/v09 with stable transfer and capability.",
+    "Hardware-in-the-loop tasks remain deferred by user preference."
+  ],
+  "next_actions": [
+    "Calibrate guardrail proxy targets against cross-eval capability components using a short sweep from v05.",
+    "Run transfer-recovery retrain from v05 with adjusted transfer loss/fitness versus capability penalty balance.",
+    "Cross-evaluate against v07/v09/v02 and regenerate storyboard deltas for the same calibrated-large scenarios."
+  ],
+  "return_trigger": "Cross-eval shows guardrail line beating v02 on both capability and weighted transfer without regressing storyboard-critical latency-storm/storm tracks.",
+  "return_trigger_status": "pending",
+  "lesson_tags": [
+    "guardrail-v04-v05",
+    "proxy-calibration-gap",
+    "shared-env-1200",
+    "calibrated-large-storyboard",
+    "release-v0.1.0"
+  ],
+  "scenario_class": "common",
+  "reusable_artifacts": [
+    "scripts/analyze_storyboard_metrics.py",
+    "artifacts/world-randomization-calibrated-v1.json",
+    "skills/agent-management/scripts/validate_handoff_packet.py"
+  ],
+  "portability_notes": [
+    "Guardrail training path validated on CUDA torch 2.10.0+cu130.",
+    "Cross-eval/storyboard runs remain CPU-compatible for analysis pass."
+  ],
+  "reference_subset_recommended": [
+    "AGENTS.md",
+    ".agents/handoff-protocol.md",
+    ".agents/handoff-packet-template.md",
+    "IMPLEMENTED.md",
+    "TODO.md",
+    "skills/agent-management/SKILL.md",
+    "skills/dynamic-diversity-research/SKILL.md",
+    "skills/dynamic-diversity-research/references/session-lessons-latest.md"
+  ]
+}

--- a/IMPLEMENTED.md
+++ b/IMPLEMENTED.md
@@ -20,6 +20,14 @@
 - Generated guardrail storyline visual package (`v04` vs `v02`) in large calibrated world:
   - `artifacts/viz-storyboard-v04-v02-calib-large-v1/convergence-storyboard.gif`
   - delta summary: `artifacts/viz-storyboard-v04-v02-calib-large-v1/compare-summary.md`.
+- Ran transfer-recovery calibration line from `v05`:
+  - checkpoint: `artifacts/model-core-coevo-guardrail-transfercal-v06.pt`
+  - metrics: `artifacts/model-core-coevo-guardrail-transfercal-v06.metrics.json`
+  - calibrated cross-eval: `artifacts/cross-eval-guardrail-v06-v05-v02-v07-v09-calib-extreme-r3.json`
+  - result: `v06` moved to rank 3, surpassing `v02` overall (`0.564079 > 0.561211`) with capability gain (`0.476272`) and near-baseline transfer (`0.434984`).
+- Added new targeted compare GIFs for ongoing visual evidence:
+  - `artifacts/v06-vs-v02-car-latency-storm-ish.gif`
+  - `artifacts/v07-vs-v06-drone-storm-ish.gif`.
 - Ran a shared-environment 1200-generation extreme coevolution cycle with all five embodiments (`hexapod,car,drone,polymorph120,humanoid120`) in `large_v1_extreme`:
   - checkpoint: `artifacts/model-core-coevo-1200-shared-extreme-v03.pt`
   - metrics: `artifacts/model-core-coevo-1200-shared-extreme-v03.metrics.json`

--- a/IMPLEMENTED.md
+++ b/IMPLEMENTED.md
@@ -314,6 +314,69 @@
     - `artifacts/noisecurr-v01-v04-vs-v03-car-crosswind-thrust.gif`
     - `artifacts/noisecurr-v01-v04-vs-v03-polymorph-storm.gif`
 
+- Added rich environment v1 (`new_env_v1` world profile) — 40×40×20 toroidal world with three new environment object types, all anonymous (function/usage discovered through interaction, not labeled):
+  - **Toroidal boundary**: `F.pad(..., mode='circular')` circular-padding convolution replaces zero-padding; no hard walls; life, resources, and stress wrap continuously. `torch.roll`-based wind flow already wrapped; now consistent.
+  - **T-shape occlusion objects** (`num_occlusion_objects`, `occlusion_seed`): permanent binary spatial masks generated at `world.init()`; block life-field propagation across walls; attenuate resource flow (×0.4 through occlusion); cast shadow (`light_field < 0.05 × occlusion`) used as hazard-safety cue by hazard system.
+  - **Physics objects** (`num_physics_objects`, `phys_mass`, `phys_friction`): N moveable objects with `phys_pos/vel/height` in `WorldState`; agents push/pull via action-field proximity force (sign of force dot product determines direction — no label); objects stack (height increments when two converge in XY); bridge hazard zones (reduce local stress proportional to height × span).
+  - **Hazard zones** (`hazard_zones: list[HazardZoneConfig]`): three kinds with correlated hint channels so agents can anticipate before activation:
+    - `light_triggered`: active when light field intensity > threshold; shadow-safe regions (occlusion casts safety zones); agents sense `light_field_mean` anonymously.
+    - `airflow`: active when wind magnitude > threshold; wind channel rises before activation (temporal hint); agents sense `wind_magnitude` anonymously.
+    - `periodic`: active when `sin(2π·t/period) > threshold`; light intensity cycles at same period — correlated signal hints at timing.
+  - Added `HazardZoneConfig` dataclass to `config.py`.
+  - Added `_build_hazard_mask()`, `_compute_hazard_stress()`, hazard-zone pre-built masks in `DynamicDiversityWorld.__init__()`.
+  - `WorldState` fields made backward-compatible (`occlusion_mask`, `phys_pos/vel/height` default to zeros when not provided).
+  - `encode_observation()` extended with anonymous hint channels: `light_mean`, `wind_mag`, `step_phase_sin`, per-object proximity distances.
+  - `SignalingWorld` passes through all new `WorldConfig` fields.
+  - `world_config_for_profile("new_env_v1")` returns 40×40×20 with 3 occlusion objects, 3 physics objects, 3 hazard zones (one of each kind).
+  - World config default grid remains 20×20×10 for backward compatibility; `base` profile unchanged.
+  - Files: `config.py`, `sim/world.py`, `sim/signaling.py`.
+
+- Added cross-world champion evaluation and evolution under `new_env_v1`:
+  - `scripts/eval_evolve_new_env.py`: Phase-1 benchmarks top 5 champions on 3 world configs (legacy 20×20×10, base 40×40×20, `new_env_v1`); Phase-2 coevolution seeds from top-3 `new_env_v1` performers.
+  - Phase-1 key finding: models that scored poorly on legacy flat world (v09: −0.097) ranked highest in the rich structured environment (v09: +0.034) — the affordances expose previously-latent strategies.
+  - Phase-2: 40 generations, pop=6, seeded from champion-v09+v08+guardrail-v04; peak fitness +0.0506 at gen 7; signal reliability 82% at gen 40.
+  - New champion: `artifacts/new-env-evolution/champion-new-env-v1.pt` (pi5 profile, multi-scale gating, world predictor enabled).
+  - Visualizations: `viz-new-env-champion-storm.gif`, `viz-new-env-compare-storm/blackout.gif`, `viz-new-env-champion-hazard-sweep.gif`, `viz-training-progress.png`, `viz-phase1-eval.png`.
+
+- Added population-level Genetic Diversity Index (GDI) — external metric, not fed to agents as a reward signal:
+  - `sim/population_metrics.py`: `genetic_diversity_index(population, io_traces, lineage)` → `{weight_div, behavior_div, lineage_entropy, species_count, species_frac, gdi}`.
+    - `weight_div`: mean pairwise cosine distance of flattened model parameter vectors.
+    - `behavior_div`: mean pairwise cosine distance of per-agent IO-trace mean vectors.
+    - `lineage_entropy`: Shannon entropy of parent-assignment frequencies (normalised).
+    - `species_count`: single-linkage cluster count on IO traces at cosine-distance threshold 0.3.
+    - `gdi` composite: 0.35×weight + 0.35×behavior + 0.20×lineage + 0.10×species_frac.
+  - `dof_coordination_metrics(io_traces, io_channels)` → `{per_channel_firing_rate, channel_entropy, co_activation_top5, coverage_fraction}`.
+  - GDI and DOF coordination fields logged every coevolution generation (`gdi`, `weight_div`, `behavior_div`, `lineage_entropy`, `species_count`, `dof_channel_entropy`, `dof_coverage_frac`).
+  - IO trace collection and GDI computation gated behind `diversity_selection_bonus > 0.0` to avoid expensive rollouts when not needed.
+  - `diversity_selection_bonus` flag adds behavioural-distance bonus relative to current best agent (computed post-scoring, correct best reference).
+
+- Added JEPA-style latent world predictor (LeWM-inspired):
+  - `models/world_predictor.py`: `LatentWorldPredictor(latent_dim, action_dim, hidden_dim=64)` — 2-layer MLP, `(latent + action) → latent`, GELU activation.
+  - `train/losses.py`: `world_prediction_loss(pred_latent, actual_latent, sigreg_weight=0.1)` — MSE against detached target + SIGReg (relu(1 − pred_latent.var(dim=0).mean())) to prevent representational collapse. SIGReg uses predicted latent variance for correct gradient flow.
+  - `train/cli.py`: `--enable-world-predictor` flag; `_train_world_predictor()` helper runs a short rollout per epoch to train the predictor; shared predictor in coevolution mode (uses representative agent); separate AdamW optimizer.
+  - `--world-pred-loss-weight 0.05` controls MSE+SIGReg contribution.
+  - World predictor loss logged as `mean_world_pred_loss` per epoch/generation.
+
+- Added DOF spatial coupling — closes the causal loop between DOF articulation and world simulation:
+  - **Root cause**: all IO channels were collapsed to a single scalar before `world.step()` (`applied.mean(dim=1).repeat(1, z*y*x)`), meaning every joint produced identical world effects with no incentive to differentiate.
+  - `sim/embodiments.py`: `dof_spatial_map(embodiment, z, y, x, device)` → `[control_dim, z*y*x]` Gaussian influence tensor. Each DOF gets an anatomical centre position in normalised [-1,1]³ and sigma; rows L1-normalised. Predefined for all 5 embodiments:
+    - hexapod: 6 legs → 6 ground-contact clusters (z=−0.7, XY quadrants); 4 arms → upper-centre
+    - car: throttle/brake → forward/back; steer → lateral; suspension/gear/camera → centre
+    - drone: 4 rotors → 4 XY quadrant top-Z; pitch/roll/yaw → tilt asymmetry; thrust → full Z-column
+    - polymorph120/humanoid120: grouped by locomotion (ground ring) / manipulator (mid-height) / spine (central axis) / thruster/head (top hemisphere)
+  - Replaces scalar broadcast with `applied @ spatial_map` at all 4 action-field sites: `run_gradient_epoch()`, `evaluate_fitness()`, `sim/cli.py:profile_embodiment_metrics()`, `sim/viz_cli.py:_simulate()`.
+  - Falls back to scalar broadcast when embodiment unavailable (non-transfer rollouts).
+  - Map is anonymous to the model — the permutation remapping (io_channels → control_dim) still applies; model must discover which channel affects which region through interaction.
+  - `_build_action_field(io, mapping, world, spatial_map)` helper in `train/cli.py`.
+
+- Added articulation differentiation losses and per-DOF observability:
+  - `train/losses.py`: `io_differentiation_loss(io, margin=0.15)` — `relu(margin − io.std(dim=1)).mean()`; penalises near-uniform IO outputs across channels (channel collapse); zero gradient once channels exceed margin.
+  - `train/losses.py`: `dof_coverage_loss(applied, threshold=0.05)` — `relu(threshold − applied.abs().mean(dim=0)).mean()`; penalises permanently-silent control channels.
+  - Both wired into `loss_fn()` as `io_diff_weight=0.02`, `dof_coverage_weight=0.01`; logged as `io_diff_loss`, `dof_coverage_loss`.
+  - `sim/cli.py`: per-DOF profiling: `io_profile.per_dof` entries with `dof_name`, `usage`, `firing_frac`, `mismatch_contribution` per control index (e.g. `"dof_name": "leg_front_l"`); accumulates `channel_mismatch_acc` and `channel_firing_acc` per-step.
+  - `sim/viz_cli.py`: `_simulate()` now returns `io_frames` `[T, io_channels]`; `_save_single()` replaces trajectory panel with IO channel activity heatmap (RdBu_r diverging, channels × steps, remap event lines overlaid) — channel collapse shows as uniform block; differentiation shows as varied bands.
+  - `WorldState._clone_state()` updated to include new fields (was missing occlusion/physics fields, caused viz crash).
+
 ## Lessons Learned
 
 - Detaching rollout memory between steps is required to avoid graph reuse errors in unrolled training.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,37 @@ Noisy-signal curriculum training (optional):
 - `--noise-strength-start 0.25`
 - `--noise-strength-end 1.0`
 
+Rich environment features (optional, configured via world profile or WorldConfig):
+
+World profiles:
+- `base` / `default`: 20×20×10 toroidal grid (circular-padding convolution, no hard walls)
+- `pi5` / `edge`: 20×20×10 (memory-constrained; same as old base default)
+- `new_env_v1`: 40×40×20 toroidal + 3 T-shape occlusion objects + 3 physics objects + 3 hazard zones (light_triggered, airflow, periodic)
+- `large_v1`: 56×56×28 with actuation/sensor realism
+- `large_v1_extreme`: 64×64×32 extreme realism
+
+Structural environment objects (anonymous — function discovered through interaction):
+- **Occlusion** (`--num-occlusion-objects N`): T-shaped binary masks block life propagation, cast light shadows used as hazard-safety cues
+- **Physics objects** (`--num-physics-objects N`): push/pull/stack/bridge via action-field proximity; agents discover affordances without labels
+- **Hazard zones** (`hazard_zones` in `WorldConfig`): `light_triggered` (shadow=safe), `airflow` (wind precedes activation), `periodic` (light-phase correlated)
+
+JEPA latent world predictor (optional):
+
+- `--enable-world-predictor`: attach a `LatentWorldPredictor` alongside `ModelCore`
+- `--world-pred-loss-weight 0.05`: MSE + SIGReg weight
+
+Genetic Diversity Index (coevolution, optional):
+
+- `--diversity-selection-bonus 0.1`: add behavioural-distance bonus relative to current best agent
+- GDI fields appear in generation logs: `gdi`, `weight_div`, `behavior_div`, `lineage_entropy`, `species_count`, `dof_channel_entropy`, `dof_coverage_frac`
+- IO trace collection is gated behind `diversity_selection_bonus > 0` to avoid overhead when not needed
+
+Articulation differentiation losses (optional):
+
+- `--io-diff-weight 0.02`: penalise near-uniform IO outputs across channels (channel collapse)
+- `--dof-coverage-weight 0.01`: penalise permanently-silent control channels
+- Per-DOF named profiling: `add-sim profiler` now returns `io_profile.per_dof` with `dof_name`, `usage`, `firing_frac`, `mismatch_contribution` per joint
+
 ## Run simulator rollout
 
 ```bash
@@ -185,7 +216,8 @@ Noisy-signal curriculum training (optional):
 - runtime memory (`state_mb`, `memory_tensor_mb`, `peak_gpu_alloc_mb`)
 - effectiveness/dynamism proxies (`mean_mismatch`, `channel_firing_fraction`, `readiness_sparsity`, `memory_weight_entropy`)
 - autopoietic closure metrics (`closure_resilience`, `organizational_persistence`, `self_repair_response`, `resource_cycle_efficiency`, `autopoietic_score`)
-- low/high usage control-channel indices for embodiment bottleneck analysis.
+- per-DOF named profiling: `io_profile.per_dof` with `dof_name`, `usage`, `firing_frac`, `mismatch_contribution` per control (e.g. `"dof_name": "leg_front_l"`)
+- DOF coordination: `channel_entropy`, `co_activation_top5`, `coverage_fraction`
 
 Visualization is independent of training loop execution and can use any checkpoint:
 

--- a/TODO.md
+++ b/TODO.md
@@ -88,3 +88,24 @@
 - [x] Add metric export (`csv/json`) from visualization runs (integrated in `viz_cli.py`).
 - [x] Add batch rendering scripts for multiple force modes (`poke`, `press`, `push`, `continuous-blow`, `thrust`, `move`) via `add-viz batch-force`.
 - [x] Add object trajectory overlays to comparison visualizations.
+- [x] Add toroidal world boundary (circular-padding `F.pad` convolution replaces zero-padding; life/resources/stress wrap continuously).
+- [x] Add structural T-shape occlusion objects with shadow casting (anonymous affordance discovery).
+- [x] Add anonymous physics objects with push/pull/stack/bridge dynamics.
+- [x] Add environmental hazard zones with temporal hint channels (light_triggered, airflow, periodic).
+- [x] Add `new_env_v1` world profile (40×40×20, 3 occlusion, 3 physics, 3 hazard zones).
+- [x] Add population-level Genetic Diversity Index (GDI) as external metric (weight_div, behavior_div, lineage_entropy, species_count).
+- [x] Add DOF coordination metrics (channel_entropy, co_activation_top5, coverage_fraction).
+- [x] Add JEPA-style latent world predictor (`LatentWorldPredictor`, SIGReg, `--enable-world-predictor`).
+- [x] Add DOF spatial coupling — close the causal loop between articulation and world effects (`dof_spatial_map()`, anatomical Gaussian influence maps for all 5 embodiments).
+- [x] Add articulation differentiation losses (`io_differentiation_loss`, `dof_coverage_loss`) to prevent channel collapse.
+- [x] Add per-DOF named profiling to `sim profiler` (`dof_name`, `usage`, `firing_frac`, `mismatch_contribution`).
+- [x] Add IO channel activity heatmap panel to `viz run` single-model visualization.
+- [x] Evaluate and evolve top champions under new_env_v1; produce `champion-new-env-v1.pt`.
+- [ ] Staged new-env curriculum: occlusion-only → physics → hazards (fitness peaked gen-7 then declined; staged phases would sustain improvement).
+- [ ] Diversity budget: stronger GDI selection pressure (species=1 throughout 40-gen run; explore diversity-weighted tournament selection).
+- [ ] Learned/procedural DOF spatial maps (hardcoded Gaussian anatomy works; could be learned from embodiment topology graph).
+- [ ] Multi-channel action field in world.step() (currently sums to [B, z*y*x]; [B, control_dim, z*y*x] would enable richer differential effects).
+- [ ] Per-embodiment GDI breakdown (GDI is population-wide; per-embodiment diversity shows specialisation vs generalism).
+- [ ] Hazard-aware signal injection in SignalingWorld (signal types none/peer/env/threat don't connect to 3 hazard zone kinds).
+- [ ] CI pipeline: smoke tests + profiler on PR (no .github/workflows; add basic pytest + sim profiler run on push).
+- [ ] World predictor: per-embodiment prediction heads (single shared predictor misses embodiment-specific dynamics).

--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,7 @@
 - [ ] Add scenario-targeted remediation curriculum for `latency-storm` and `storm` in `hexapod/car/drone` where `v03` regressed vs `v07` in storyboard deltas.
 - [ ] Align in-training capability proxies with cross-eval capability metrics (signal reliability/conjoining calibration mismatch) so guardrail penalties predict ranking outcomes.
 - [ ] Recover transfer after guardrail capability gains (`v04/v05`) by rebalancing transfer-loss/fitness and capability penalties without sacrificing restored capability.
+- [ ] Push `v06` beyond champion line (`v07/v09`) by targeting remaining score gap through scenario-weighted transfer recovery on `car`/`hexapod` without dropping capability floor.
 
 ## Hardware-In-The-Loop
 

--- a/scripts/eval_evolve_new_env.py
+++ b/scripts/eval_evolve_new_env.py
@@ -1,0 +1,267 @@
+"""
+Evaluate and evolve top champions under the new 40x40x20 toroidal environment.
+
+Phase 1: Benchmark top candidates on three worlds:
+  - legacy: 20x20x10 zero-padded (original training world)
+  - base_new: 40x40x20 toroidal (bare)
+  - new_env_v1: 40x40x20 toroidal + occlusion + physics + hazards
+
+Phase 2: Evolve the top seeds in the new_env_v1 world using the strongest
+         training config (curriculum, transfer, autopoietic, guardrail, noise,
+         force curriculum, world predictor, GDI logging).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+
+# Allow running from project root: python scripts/eval_evolve_new_env.py
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from ai_embedded_dynamic_diversity.config import (
+    ModelConfig,
+    WorldConfig,
+    HazardZoneConfig,
+    world_config_for_profile,
+)
+from ai_embedded_dynamic_diversity.models import ModelCore
+from ai_embedded_dynamic_diversity.sim.signaling import SignalingWorld
+from ai_embedded_dynamic_diversity.sim.population_metrics import genetic_diversity_index
+from ai_embedded_dynamic_diversity.train.cli import evaluate_fitness, _build_transfer_states, run
+from ai_embedded_dynamic_diversity.train.device import choose_device
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+DEVICE = "cuda"
+EVAL_STEPS = 16
+EVAL_BATCH = 8
+EVAL_ENV_VOLATILITY = 0.45
+
+CANDIDATES = [
+    "artifacts/model-core-champion-v08.pt",
+    "artifacts/model-core-coevo-guardrail-transfercal-v06.pt",
+    "artifacts/model-core-coevo-guardrail-shared-extreme-v04.pt",
+    "artifacts/model-core-coevo-guardrail-shared-extreme-v05.pt",
+    "artifacts/model-core-champion-v09.pt",
+]
+
+OUT_DIR = Path("artifacts/new-env-evolution")
+EVAL_JSON = OUT_DIR / "phase1-eval.json"
+
+
+def _make_world(wcfg: WorldConfig, dev: torch.device) -> SignalingWorld:
+    return SignalingWorld(
+        wcfg.x, wcfg.y, wcfg.z, wcfg.resource_channels, wcfg.decay,
+        device=str(dev),
+        actuation_delay_steps=wcfg.actuation_delay_steps,
+        actuation_noise_std=wcfg.actuation_noise_std,
+        sensor_latency_steps=wcfg.sensor_latency_steps,
+        sensor_dropout_burst_prob=wcfg.sensor_dropout_burst_prob,
+        surface_friction_scale=wcfg.surface_friction_scale,
+        disturbance_correlation_horizon=wcfg.disturbance_correlation_horizon,
+        num_occlusion_objects=wcfg.num_occlusion_objects,
+        occlusion_seed=wcfg.occlusion_seed,
+        num_physics_objects=wcfg.num_physics_objects,
+        phys_mass=wcfg.phys_mass,
+        phys_friction=wcfg.phys_friction,
+        hazard_zones=wcfg.hazard_zones,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Evaluation
+# ---------------------------------------------------------------------------
+
+def phase1_eval(dev: torch.device) -> list[dict]:
+    worlds = {
+        "legacy_20x20x10":  _make_world(WorldConfig(x=20, y=20, z=10), dev),
+        "base_40x40x20":    _make_world(WorldConfig(), dev),
+        "new_env_v1":       _make_world(world_config_for_profile("new_env_v1"), dev),
+    }
+    wcfgs = {
+        "legacy_20x20x10":  WorldConfig(x=20, y=20, z=10),
+        "base_40x40x20":    WorldConfig(),
+        "new_env_v1":       world_config_for_profile("new_env_v1"),
+    }
+
+    results = []
+    for ckpt_path in CANDIDATES:
+        if not os.path.exists(ckpt_path):
+            print(f"  SKIP (missing): {ckpt_path}")
+            continue
+        ckpt = torch.load(ckpt_path, map_location=dev, weights_only=False)
+        mcfg_dict = ckpt.get("model_config", {})
+        mcfg = ModelConfig(**mcfg_dict)
+        model = ModelCore(**asdict(mcfg)).to(dev)
+        model.load_state_dict(ckpt["model"])
+
+        row = {"checkpoint": ckpt_path, "profile": ckpt.get("profile"), "model_config": mcfg_dict}
+        print(f"\n  {Path(ckpt_path).name}  (profile={row['profile']})")
+
+        transfer_states = _build_transfer_states(
+            ["hexapod", "car", "drone", "polymorph120"],
+            mcfg, dev, seed=9001
+        )
+
+        for world_name, world in worlds.items():
+            wcfg = wcfgs[world_name]
+            fitness = evaluate_fitness(
+                model, world, mcfg, wcfg, dev,
+                steps=EVAL_STEPS,
+                batch=EVAL_BATCH,
+                env_volatility=EVAL_ENV_VOLATILITY,
+                transfer_states=transfer_states,
+                transfer_fitness_weight=0.10,
+                transfer_samples_per_step=2,
+                noise_profile="dropout-quant-v2",
+                noise_strength=0.8,
+                noise_seed=12345,
+                autopoietic_fitness_weight=0.15,
+                genetic_memory_persistence_weight=0.05,
+                force_curriculum_mode="continuous-blow",
+                force_curriculum_strength=0.6,
+            )
+            row[world_name] = round(fitness, 5)
+            print(f"    {world_name:22s}: {fitness:+.5f}")
+
+        results.append(row)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Evolution
+# ---------------------------------------------------------------------------
+
+def phase2_evolve(seeds: list[str], dev: torch.device) -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    save_path = str(OUT_DIR / "champion-new-env-v1.pt")
+    metrics_path = str(OUT_DIR / "champion-new-env-v1.metrics.json")
+
+    print("\n=== Phase 2: Evolution in new_env_v1 world ===")
+    print(f"  Seeds: {seeds}")
+    print(f"  Save:  {save_path}")
+
+    # Build the init_weights_cycle CSV from seed paths
+    cycle_csv = ",".join(seeds)
+
+    from typer.testing import CliRunner
+    import typer
+    mini_app = typer.Typer()
+    mini_app.command()(run)
+    runner = CliRunner()
+
+    args = [
+        # Epochs and batch
+        "--epochs=40",
+        "--batch-size=12",
+        "--unroll-steps=16",
+        "--lr=1.5e-4",
+        "--device=cuda",
+        # Architecture — keep pi5 profile that champions use
+        "--profile=pi5",
+        "--world-profile=new_env_v1",
+        # Coevolution
+        "--coevolution",
+        "--population-size=6",
+        "--elite-fraction=0.4",
+        "--mutation-std=0.008",
+        # Curriculum
+        "--enable-curriculum",
+        "--curriculum-power=1.2",
+        "--remap-probability-start=0.12",
+        "--remap-probability-end=0.45",
+        "--env-volatility-start=0.08",
+        "--env-volatility-end=0.65",
+        # Transfer
+        "--enable-embodiment-transfer-loss",
+        "--embodiments=hexapod,car,drone,polymorph120",
+        "--transfer-loss-weight=0.40",
+        "--transfer-fitness-weight=0.12",
+        "--transfer-samples-per-step=3",
+        # Autopoietic
+        "--enable-autopoietic-objective",
+        "--autopoietic-loss-weight=0.14",
+        "--autopoietic-fitness-gain=0.16",
+        # Capability guardrail
+        "--enable-capability-guardrail",
+        "--signal-reliability-floor=0.50",
+        "--conjoining-gain-floor=0.25",
+        "--capability-guardrail-penalty-weight=0.20",
+        # Noise curriculum
+        "--noise-profile=dropout-quant-v2",
+        "--enable-noise-curriculum",
+        "--noise-strength-start=0.2",
+        "--noise-strength-end=0.9",
+        # Force curriculum
+        "--force-curriculum-mode=continuous-blow",
+        "--force-curriculum-strength-start=0.1",
+        "--force-curriculum-strength-end=0.8",
+        # World predictor (JEPA)
+        "--enable-world-predictor",
+        "--world-pred-loss-weight=0.04",
+        # GDI diversity bonus
+        "--diversity-selection-bonus=0.05",
+        # Architecture extras matching champions
+        "--enable-multi-scale-gating",
+        # AMP
+        "--use-amp",
+        "--allow-tf32",
+        # Seeds and output
+        "--init-weights-cycle=" + cycle_csv,
+        "--seed=314159",
+        "--save-path=" + save_path,
+        "--metrics-path=" + metrics_path,
+    ]
+
+    result = runner.invoke(mini_app, args)
+    # Write output to log file
+    log_path = OUT_DIR / "train.log"
+    log_path.write_text(result.output, encoding="utf-8")
+    print(f"  Training output written to {log_path}")
+
+    if result.exception:
+        import traceback
+        traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+        raise result.exception
+
+    print(f"  Evolution complete. exit_code={result.exit_code}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    dev = choose_device(DEVICE, strict=True)
+    print(f"Device: {dev}  ({torch.cuda.get_device_name(0) if dev.type == 'cuda' else 'cpu'})")
+
+    # Phase 1
+    print("\n=== Phase 1: Evaluating top candidates on three worlds ===")
+    eval_results = phase1_eval(dev)
+    EVAL_JSON.write_text(json.dumps(eval_results, indent=2), encoding="utf-8")
+    print(f"\n  Results saved to {EVAL_JSON}")
+
+    # Rank by new_env_v1 fitness and pick top 3 as seeds
+    ranked = sorted(
+        [r for r in eval_results if "new_env_v1" in r],
+        key=lambda r: r["new_env_v1"],
+        reverse=True,
+    )
+    print("\n  Ranking by new_env_v1 fitness:")
+    for i, r in enumerate(ranked):
+        name = Path(r["checkpoint"]).name
+        print(f"    #{i+1}  {name:52s}  new_env={r['new_env_v1']:+.5f}  legacy={r.get('legacy_20x20x10',0):+.5f}")
+
+    seeds = [r["checkpoint"] for r in ranked[:3]]
+
+    # Phase 2
+    phase2_evolve(seeds, dev)

--- a/scripts/eval_evolve_new_env.py
+++ b/scripts/eval_evolve_new_env.py
@@ -26,12 +26,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from ai_embedded_dynamic_diversity.config import (
     ModelConfig,
     WorldConfig,
-    HazardZoneConfig,
     world_config_for_profile,
 )
 from ai_embedded_dynamic_diversity.models import ModelCore
 from ai_embedded_dynamic_diversity.sim.signaling import SignalingWorld
-from ai_embedded_dynamic_diversity.sim.population_metrics import genetic_diversity_index
 from ai_embedded_dynamic_diversity.train.cli import evaluate_fitness, _build_transfer_states, run
 from ai_embedded_dynamic_diversity.train.device import choose_device
 

--- a/scripts/viz_new_env.py
+++ b/scripts/viz_new_env.py
@@ -1,0 +1,597 @@
+"""
+Visualize champion models in the new_env_v1 world (40x40x20 toroidal, occlusion,
+physics objects, hazard zones).
+
+Produces:
+  artifacts/new-env-evolution/
+    viz-new-env-champion-storm.gif          new champion, storm scenario
+    viz-new-env-champion-hazard-sweep.gif   champion across all 3 hazard types
+    viz-new-env-compare-storm.gif           champion-new-env-v1 vs champion-v08
+    viz-new-env-compare-blackout.gif        same, blackout scenario
+    viz-new-env-phys-obj-traj.gif           physics object trajectory panel
+    viz-training-progress.gif               fitness + GDI over 40 generations
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib import animation
+from matplotlib.gridspec import GridSpec
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from ai_embedded_dynamic_diversity.config import world_config_for_profile, WorldConfig
+from ai_embedded_dynamic_diversity.models import ModelCore
+from ai_embedded_dynamic_diversity.config import ModelConfig
+from ai_embedded_dynamic_diversity.sim.signaling import SignalingWorld
+from ai_embedded_dynamic_diversity.sim.world import WorldState, EnvironmentControls
+from ai_embedded_dynamic_diversity.sim.embodiments import device_map_for_embodiment, get_embodiment
+from ai_embedded_dynamic_diversity.sim.viz_cli import (
+    VizParams, _controls_for_step, _simulate as _sim_legacy,
+    _clone_state, _classify_adaptation_signature,
+)
+
+OUT = Path("artifacts/new-env-evolution")
+OUT.mkdir(parents=True, exist_ok=True)
+
+DEVICE = torch.device("cuda")
+STEPS = 120
+REMAP_EVERY = 18
+SEED = 42
+
+# ---------------------------------------------------------------------------
+# Load helpers
+# ---------------------------------------------------------------------------
+
+def load_model(path: str) -> tuple[ModelCore, ModelConfig]:
+    ck = torch.load(path, map_location=DEVICE, weights_only=False)
+    cfg = ModelConfig(**ck["model_config"])
+    m = ModelCore(**asdict(cfg)).to(DEVICE)
+    m.load_state_dict(ck["model"], strict=False)
+    m.eval()
+    return m, cfg
+
+
+def make_world(wcfg: WorldConfig) -> SignalingWorld:
+    return SignalingWorld(
+        wcfg.x, wcfg.y, wcfg.z, wcfg.resource_channels, wcfg.decay,
+        device=str(DEVICE),
+        actuation_delay_steps=wcfg.actuation_delay_steps,
+        actuation_noise_std=wcfg.actuation_noise_std,
+        sensor_latency_steps=wcfg.sensor_latency_steps,
+        sensor_dropout_burst_prob=wcfg.sensor_dropout_burst_prob,
+        surface_friction_scale=wcfg.surface_friction_scale,
+        disturbance_correlation_horizon=wcfg.disturbance_correlation_horizon,
+        num_occlusion_objects=wcfg.num_occlusion_objects,
+        occlusion_seed=wcfg.occlusion_seed,
+        num_physics_objects=wcfg.num_physics_objects,
+        phys_mass=wcfg.phys_mass,
+        phys_friction=wcfg.phys_friction,
+        hazard_zones=wcfg.hazard_zones,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simulation helper for the rich world (returns extra channels)
+# ---------------------------------------------------------------------------
+
+def simulate_rich(
+    model: ModelCore,
+    cfg: ModelConfig,
+    world: SignalingWorld,
+    wcfg: WorldConfig,
+    params: VizParams,
+    embodiment_name: str,
+    seed_offset: int,
+) -> dict:
+    torch.manual_seed(seed_offset)
+    model.eval()
+    state = world.init(batch_size=1)
+    memory = model.init_memory(1, cfg.memory_slots, cfg.memory_dim, DEVICE)
+    embodiment = get_embodiment(embodiment_name)
+    mapping = device_map_for_embodiment(cfg.io_channels, embodiment, device=DEVICE, permutation_seed=seed_offset)
+    proj = torch.randn(cfg.signal_dim, len(embodiment.controls), device=DEVICE) * 0.3
+
+    life_frames, stress_frames, occ_frames = [], [], []
+    mismatch_v, vitality_v, stress_v, wind_v, force_v = [], [], [], [], []
+    hazard_v = []
+    phys_traj = [[] for _ in range(wcfg.num_physics_objects)]
+    remap_steps = []
+
+    for step in range(params.steps):
+        remap_code = torch.zeros(1, cfg.max_remap_groups, device=DEVICE)
+        if step > 0 and step % params.remap_every == 0:
+            remap_steps.append(step)
+            mapping = device_map_for_embodiment(cfg.io_channels, embodiment, device=DEVICE, permutation_seed=seed_offset + step)
+            remap_code[:, step % cfg.max_remap_groups] = 1.0
+
+        controls = _controls_for_step(world, params, step, DEVICE)
+        with torch.no_grad():
+            obs = world.encode_observation(state, signal_dim=cfg.signal_dim)
+            out = model(obs, memory, remap_code)
+            memory = out["memory"]
+            desired = torch.tanh(obs @ proj)
+            applied = out["io"] @ mapping
+            mismatch_v.append(float(torch.mean((applied - desired) ** 2).item()))
+            action = applied.mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+            state = world.step(state, action, controls=controls)
+
+        vitality_v.append(float(state.life.mean().item()))
+        stress_v.append(float(state.stress.mean().item()))
+        wind_v.append(float(torch.norm(controls.wind, dim=1).mean().item()))
+        force_v.append(float((controls.force_strength * controls.force_active).mean().item()))
+        hazard_v.append(float(state.stress.max().item()))
+
+        # Mid-Z slice for life and stress
+        mid_z = world.z // 2
+        life_frames.append(state.life[0, 0, mid_z].detach().cpu().numpy().copy())
+        stress_frames.append(state.stress[0, 0, mid_z].detach().cpu().numpy().copy())
+        occ_frames.append(state.occlusion_mask[0, 0, mid_z].detach().cpu().numpy().copy())
+
+        for i in range(wcfg.num_physics_objects):
+            phys_traj[i].append(state.phys_pos[0, i].detach().cpu().tolist())
+
+    return {
+        "life_frames": life_frames,
+        "stress_frames": stress_frames,
+        "occ_frames": occ_frames,
+        "mismatch_values": mismatch_v,
+        "vitality_values": vitality_v,
+        "stress_values": stress_v,
+        "wind_values": wind_v,
+        "force_values": force_v,
+        "hazard_values": hazard_v,
+        "phys_traj": phys_traj,
+        "remap_steps": remap_steps,
+        "object_pos": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario param helpers
+# ---------------------------------------------------------------------------
+
+def _base_params(force_mode: str = "continuous-blow", volatility_wind: float = 0.6) -> VizParams:
+    return VizParams(
+        steps=STEPS, remap_every=REMAP_EVERY,
+        force_mode=force_mode, force_start=12, force_duration=80, force_sustain=0.95,
+        force_x=0.9, force_y=0.2, force_z=0.0,
+        wind_x=volatility_wind, wind_y=0.3, wind_z=0.0, wind_variation=0.35,
+        light_x=-0.35, light_y=0.0, light_z=0.25, light_intensity=0.65,
+        light_drift_x=0.005, light_drift_y=0.001, light_drift_z=0.0,
+    )
+
+
+def _blackout_params() -> VizParams:
+    return VizParams(
+        steps=STEPS, remap_every=REMAP_EVERY,
+        force_mode="press", force_start=20, force_duration=50, force_sustain=0.85,
+        force_x=0.7, force_y=0.0, force_z=0.0,
+        wind_x=0.25, wind_y=0.0, wind_z=0.0, wind_variation=0.15,
+        light_x=0.3, light_y=0.0, light_z=0.1, light_intensity=0.12,
+        light_drift_x=-0.004, light_drift_y=0.0, light_drift_z=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GIF 1: New champion in storm scenario — 4-panel (life, stress, metrics, phys)
+# ---------------------------------------------------------------------------
+
+def viz_champion_storm(champ_model, champ_cfg, wcfg_new, world_new):
+    print("  [1/5] champion storm scenario...")
+    params = _base_params("continuous-blow", volatility_wind=0.75)
+    r = simulate_rich(champ_model, champ_cfg, world_new, wcfg_new, params, "car", SEED)
+
+    frames = len(r["life_frames"])
+    fig = plt.figure(figsize=(14, 8))
+    gs = GridSpec(2, 3, figure=fig, hspace=0.4, wspace=0.35)
+    ax_life   = fig.add_subplot(gs[0, 0])
+    ax_stress = fig.add_subplot(gs[0, 1])
+    ax_adapt  = fig.add_subplot(gs[0, 2])
+    ax_env    = fig.add_subplot(gs[1, 0])
+    ax_phys   = fig.add_subplot(gs[1, 1])
+    ax_haz    = fig.add_subplot(gs[1, 2])
+
+    # Static occlusion overlay
+    occ = r["occ_frames"][0]
+    h_life   = ax_life.imshow(r["life_frames"][0], cmap="viridis", vmin=0, vmax=1)
+    ax_life.imshow(occ, cmap="Reds", alpha=0.45, vmin=0, vmax=1)
+    ax_life.set_title("Life (mid-Z) + Occlusion")
+
+    h_stress = ax_stress.imshow(r["stress_frames"][0], cmap="hot", vmin=0, vmax=1)
+    ax_stress.set_title("Stress field")
+
+    # Adaptation lines
+    ax_adapt.set_xlim(0, frames - 1); ax_adapt.set_ylim(0, 1.15)
+    l_mis, = ax_adapt.plot([], [], color="crimson",    label="mismatch")
+    l_vit, = ax_adapt.plot([], [], color="limegreen",  label="vitality")
+    for rs in r["remap_steps"]:
+        ax_adapt.axvline(rs, color="dodgerblue", alpha=0.3, lw=1)
+    ax_adapt.legend(fontsize=7); ax_adapt.set_title("Adaptation")
+
+    # Env controls
+    ax_env.set_xlim(0, frames - 1); ax_env.set_ylim(0, max(max(r["wind_values"]), max(r["force_values"]), 0.01) * 1.2)
+    l_wind,  = ax_env.plot([], [], color="cyan",   label="wind")
+    l_force, = ax_env.plot([], [], color="orange", label="force")
+    ax_env.legend(fontsize=7); ax_env.set_title("Environment")
+
+    # Physics object trajectories
+    colors_phys = ["magenta", "cyan", "yellow"]
+    phys_lines = []
+    phys_pts   = []
+    ax_phys.set_xlim(-1.1, 1.1); ax_phys.set_ylim(-1.1, 1.1)
+    ax_phys.grid(True, alpha=0.2); ax_phys.set_title("Physics obj. (X-Y)")
+    for i, traj in enumerate(r["phys_traj"]):
+        ln, = ax_phys.plot([], [], color=colors_phys[i % len(colors_phys)], lw=1.2, alpha=0.7, label=f"obj {i}")
+        pt, = ax_phys.plot([], [], "o", color=colors_phys[i % len(colors_phys)], ms=5)
+        phys_lines.append(ln); phys_pts.append(pt)
+    ax_phys.legend(fontsize=7)
+
+    # Hazard (max stress proxy)
+    ax_haz.set_xlim(0, frames - 1); ax_haz.set_ylim(0, 1.05)
+    l_haz, = ax_haz.plot([], [], color="red", lw=1.5, label="peak stress")
+    ax_haz.axhline(0.5, color="orange", ls="--", lw=0.8, alpha=0.6)
+    ax_haz.legend(fontsize=7); ax_haz.set_title("Hazard pressure")
+
+    fig.suptitle("New Champion — new_env_v1 — Storm (car)", fontsize=12)
+
+    def _init():
+        h_life.set_data(r["life_frames"][0])
+        h_stress.set_data(r["stress_frames"][0])
+        l_mis.set_data([], []); l_vit.set_data([], [])
+        l_wind.set_data([], []); l_force.set_data([], [])
+        l_haz.set_data([], [])
+        for ln, pt in zip(phys_lines, phys_pts):
+            ln.set_data([], []); pt.set_data([], [])
+        return [h_life, h_stress, l_mis, l_vit, l_wind, l_force, l_haz] + phys_lines + phys_pts
+
+    def _update(i):
+        xs = list(range(i + 1))
+        h_life.set_data(r["life_frames"][i])
+        h_stress.set_data(r["stress_frames"][i])
+        l_mis.set_data(xs, r["mismatch_values"][:i+1])
+        l_vit.set_data(xs, r["vitality_values"][:i+1])
+        l_wind.set_data(xs, r["wind_values"][:i+1])
+        l_force.set_data(xs, r["force_values"][:i+1])
+        l_haz.set_data(xs, r["hazard_values"][:i+1])
+        for k, (ln, pt) in enumerate(zip(phys_lines, phys_pts)):
+            if k < len(r["phys_traj"]) and r["phys_traj"][k]:
+                px = [p[0] for p in r["phys_traj"][k][:i+1]]
+                py = [p[1] for p in r["phys_traj"][k][:i+1]]
+                ln.set_data(px, py)
+                if px: pt.set_data([px[-1]], [py[-1]])
+        return [h_life, h_stress, l_mis, l_vit, l_wind, l_force, l_haz] + phys_lines + phys_pts
+
+    anim = animation.FuncAnimation(fig, _update, init_func=_init, frames=frames, interval=70, blit=True)
+    out = str(OUT / "viz-new-env-champion-storm.gif")
+    anim.save(out, writer=animation.PillowWriter(fps=14))
+    plt.close(fig)
+    print(f"    -> {out}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GIF 2: Champion vs Legacy (v08) comparison — storm + blackout side-by-side
+# ---------------------------------------------------------------------------
+
+def viz_compare(champ_model, champ_cfg, legacy_model, legacy_cfg, wcfg_new, world_new):
+    print("  [2/5] champion vs legacy comparison (storm + blackout)...")
+    scenarios = [("storm", _base_params("continuous-blow", 0.75)), ("blackout", _blackout_params())]
+    outputs = []
+
+    for scenario_name, params in scenarios:
+        r_new = simulate_rich(champ_model, champ_cfg, world_new, wcfg_new, params, "hexapod", SEED + 1)
+        r_leg = simulate_rich(legacy_model, legacy_cfg, world_new, wcfg_new, params, "hexapod", SEED + 2)
+
+        frames = min(len(r_new["life_frames"]), len(r_leg["life_frames"]))
+        fig, axes = plt.subplots(2, 3, figsize=(15, 8))
+        fig.suptitle(f"new-env champion vs champion-v08  |  {scenario_name}  |  hexapod", fontsize=11)
+
+        ax_nl, ax_ll = axes[0, 0], axes[0, 1]
+        ax_lines     = axes[0, 2]
+        ax_ns, ax_ls = axes[1, 0], axes[1, 1]
+        ax_phys      = axes[1, 2]
+
+        h_nl = ax_nl.imshow(r_new["life_frames"][0], cmap="viridis", vmin=0, vmax=1)
+        ax_nl.imshow(r_new["occ_frames"][0], cmap="Reds", alpha=0.4, vmin=0, vmax=1)
+        ax_nl.set_title("New champion — Life")
+
+        h_ll = ax_ll.imshow(r_leg["life_frames"][0], cmap="viridis", vmin=0, vmax=1)
+        ax_ll.imshow(r_leg["occ_frames"][0], cmap="Reds", alpha=0.4, vmin=0, vmax=1)
+        ax_ll.set_title("champion-v08 — Life")
+
+        ax_lines.set_xlim(0, frames - 1)
+        ymax = max(max(r_new["mismatch_values"]), max(r_leg["mismatch_values"]),
+                   max(r_new["vitality_values"]), max(r_leg["vitality_values"]), 0.01) * 1.15
+        ax_lines.set_ylim(0, ymax)
+        lnm, = ax_lines.plot([], [], color="tab:blue",   label="new mismatch")
+        llm, = ax_lines.plot([], [], color="tab:orange", label="v08 mismatch")
+        lnv, = ax_lines.plot([], [], color="tab:cyan",   label="new vitality",  ls="--")
+        llv, = ax_lines.plot([], [], color="tab:red",    label="v08 vitality",  ls="--")
+        ax_lines.legend(fontsize=7); ax_lines.set_title("Mismatch / Vitality")
+        for rs in r_new["remap_steps"]:
+            ax_lines.axvline(rs, color="gray", alpha=0.25, lw=0.8)
+
+        h_ns = ax_ns.imshow(r_new["stress_frames"][0], cmap="hot", vmin=0, vmax=1)
+        ax_ns.set_title("New — Stress")
+        h_ls = ax_ls.imshow(r_leg["stress_frames"][0], cmap="hot", vmin=0, vmax=1)
+        ax_ls.set_title("v08 — Stress")
+
+        ax_phys.set_xlim(-1.1, 1.1); ax_phys.set_ylim(-1.1, 1.1)
+        ax_phys.grid(True, alpha=0.2); ax_phys.set_title("Phys obj trajectories (new champ)")
+        colors_p = ["magenta", "cyan", "yellow"]
+        pl, pp = [], []
+        for i in range(len(r_new["phys_traj"])):
+            ln, = ax_phys.plot([], [], color=colors_p[i % 3], lw=1.2, alpha=0.7)
+            pt, = ax_phys.plot([], [], "o", color=colors_p[i % 3], ms=5)
+            pl.append(ln); pp.append(pt)
+
+        def _init():
+            h_nl.set_data(r_new["life_frames"][0]); h_ll.set_data(r_leg["life_frames"][0])
+            h_ns.set_data(r_new["stress_frames"][0]); h_ls.set_data(r_leg["stress_frames"][0])
+            lnm.set_data([], []); llm.set_data([], [])
+            lnv.set_data([], []); llv.set_data([], [])
+            for ln, pt in zip(pl, pp): ln.set_data([], []); pt.set_data([], [])
+            return [h_nl, h_ll, h_ns, h_ls, lnm, llm, lnv, llv] + pl + pp
+
+        def _update(i):
+            xs = list(range(i + 1))
+            h_nl.set_data(r_new["life_frames"][i]); h_ll.set_data(r_leg["life_frames"][i])
+            h_ns.set_data(r_new["stress_frames"][i]); h_ls.set_data(r_leg["stress_frames"][i])
+            lnm.set_data(xs, r_new["mismatch_values"][:i+1])
+            llm.set_data(xs, r_leg["mismatch_values"][:i+1])
+            lnv.set_data(xs, r_new["vitality_values"][:i+1])
+            llv.set_data(xs, r_leg["vitality_values"][:i+1])
+            for k, (ln, pt) in enumerate(zip(pl, pp)):
+                if k < len(r_new["phys_traj"]) and r_new["phys_traj"][k]:
+                    px = [p[0] for p in r_new["phys_traj"][k][:i+1]]
+                    py = [p[1] for p in r_new["phys_traj"][k][:i+1]]
+                    ln.set_data(px, py)
+                    if px: pt.set_data([px[-1]], [py[-1]])
+            return [h_nl, h_ll, h_ns, h_ls, lnm, llm, lnv, llv] + pl + pp
+
+        anim = animation.FuncAnimation(fig, _update, init_func=_init, frames=frames, interval=70, blit=True)
+        out = str(OUT / f"viz-new-env-compare-{scenario_name}.gif")
+        anim.save(out, writer=animation.PillowWriter(fps=14))
+        plt.close(fig)
+        print(f"    -> {out}")
+        outputs.append(out)
+    return outputs
+
+
+# ---------------------------------------------------------------------------
+# GIF 3: Hazard-sweep panel — champion in each of the 3 hazard kinds
+# ---------------------------------------------------------------------------
+
+def viz_hazard_sweep(champ_model, champ_cfg, wcfg_new, world_new):
+    print("  [3/5] hazard sweep (3 hazard kinds)...")
+    # Run under 3 different lighting / wind configs to activate each hazard type
+
+    configs = [
+        ("light_triggered", VizParams(
+            steps=STEPS, remap_every=REMAP_EVERY,
+            force_mode="press", force_start=20, force_duration=50, force_sustain=0.7,
+            force_x=0.6, force_y=0.0, force_z=0.0,
+            wind_x=0.1, wind_y=0.0, wind_z=0.0, wind_variation=0.05,
+            light_x=0.75, light_y=0.25, light_z=0.0, light_intensity=0.9,  # bright — triggers light hazard
+            light_drift_x=0.0, light_drift_y=0.002, light_drift_z=0.0,
+        )),
+        ("airflow", VizParams(
+            steps=STEPS, remap_every=REMAP_EVERY,
+            force_mode="continuous-blow", force_start=8, force_duration=80, force_sustain=1.1,
+            force_x=1.1, force_y=0.4, force_z=0.0,
+            wind_x=0.85, wind_y=0.5, wind_z=0.0, wind_variation=0.45,  # high wind — triggers airflow hazard
+            light_x=-0.3, light_y=0.0, light_z=0.2, light_intensity=0.3,
+            light_drift_x=0.003, light_drift_y=0.0, light_drift_z=0.0,
+        )),
+        ("periodic", VizParams(
+            steps=STEPS, remap_every=REMAP_EVERY,
+            force_mode="press", force_start=14, force_duration=40, force_sustain=0.8,
+            force_x=0.7, force_y=0.1, force_z=0.0,
+            wind_x=0.2, wind_y=0.1, wind_z=0.0, wind_variation=0.1,
+            light_x=0.0, light_y=0.0, light_z=0.5, light_intensity=0.55,
+            light_drift_x=0.0, light_drift_y=0.0, light_drift_z=0.0,
+        )),
+    ]
+
+    results = {}
+    for label, params in configs:
+        results[label] = simulate_rich(champ_model, champ_cfg, world_new, wcfg_new, params, "drone", SEED + 10)
+
+    frames = min(len(v["life_frames"]) for v in results.values())
+    fig, axes = plt.subplots(2, 3, figsize=(15, 8))
+    fig.suptitle("new-env champion — Hazard sweep (drone) | light / airflow / periodic", fontsize=11)
+
+    row0_ax = [axes[0, 0], axes[0, 1], axes[0, 2]]
+    row1_ax = [axes[1, 0], axes[1, 1], axes[1, 2]]
+    labels = list(results.keys())
+
+    heats, stresses, mis_lines, vit_lines = {}, {}, {}, {}
+    for idx, lbl in enumerate(labels):
+        r = results[lbl]
+        h = row0_ax[idx].imshow(r["life_frames"][0], cmap="viridis", vmin=0, vmax=1)
+        row0_ax[idx].imshow(r["occ_frames"][0], cmap="Reds", alpha=0.4, vmin=0, vmax=1)
+        row0_ax[idx].set_title(f"{lbl} — Life")
+        heats[lbl] = h
+
+        s = row1_ax[idx].imshow(r["stress_frames"][0], cmap="hot", vmin=0, vmax=1)
+        row1_ax[idx].set_title(f"{lbl} — Stress")
+        stresses[lbl] = s
+
+    fig2, ax2 = plt.subplots(1, 1, figsize=(7, 3))
+    colors_h = {"light_triggered": "gold", "airflow": "cyan", "periodic": "magenta"}
+    for lbl in labels:
+        r = results[lbl]
+        ax2.plot(r["hazard_values"], color=colors_h[lbl], label=lbl, lw=1.5)
+    ax2.set_title("Peak stress by hazard type"); ax2.legend(fontsize=8)
+    ax2.set_xlabel("step"); ax2.set_ylabel("peak stress")
+    fig2.tight_layout()
+    static_out = str(OUT / "viz-hazard-sweep-static.png")
+    fig2.savefig(static_out, dpi=120)
+    plt.close(fig2)
+    print(f"    -> {static_out} (static hazard comparison)")
+
+    def _init():
+        arts = []
+        for lbl in labels:
+            heats[lbl].set_data(results[lbl]["life_frames"][0])
+            stresses[lbl].set_data(results[lbl]["stress_frames"][0])
+            arts += [heats[lbl], stresses[lbl]]
+        return tuple(arts)
+
+    def _update(i):
+        arts = []
+        for lbl in labels:
+            heats[lbl].set_data(results[lbl]["life_frames"][i])
+            stresses[lbl].set_data(results[lbl]["stress_frames"][i])
+            arts += [heats[lbl], stresses[lbl]]
+        return tuple(arts)
+
+    anim = animation.FuncAnimation(fig, _update, init_func=_init, frames=frames, interval=75, blit=True)
+    out = str(OUT / "viz-new-env-champion-hazard-sweep.gif")
+    anim.save(out, writer=animation.PillowWriter(fps=13))
+    plt.close(fig)
+    print(f"    -> {out}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GIF 4: Training progress — fitness + GDI over 40 generations
+# ---------------------------------------------------------------------------
+
+def viz_training_progress():
+    print("  [4/5] training progress chart...")
+    metrics_path = OUT / "champion-new-env-v1.metrics.json"
+    if not metrics_path.exists():
+        print("    SKIP — metrics file not found")
+        return None
+
+    records = json.loads(metrics_path.read_text())["records"]
+    gens      = [r["generation"] for r in records]
+    best_fit  = [r["best_fitness"] for r in records]
+    mean_fit  = [r["mean_fitness"] for r in records]
+    gdi       = [r.get("gdi", 0) for r in records]
+    w_div     = [r.get("weight_div", 0) for r in records]
+    b_div     = [r.get("behavior_div", 0) for r in records]
+    lin_ent   = [r.get("lineage_entropy", 0) for r in records]
+    wpred     = [r.get("mean_world_pred_loss", 0) for r in records]
+    sig_rel   = [r.get("mean_signal_reliability", 0) for r in records]
+
+    fig, axes = plt.subplots(2, 3, figsize=(15, 7))
+    fig.suptitle("Evolution in new_env_v1 — 40 generations (pi5 × pop-6)", fontsize=12)
+
+    axes[0,0].plot(gens, best_fit,  color="gold",      lw=2, label="best fitness")
+    axes[0,0].plot(gens, mean_fit,  color="lightblue", lw=1, ls="--", label="mean fitness")
+    axes[0,0].fill_between(gens, mean_fit, best_fit, alpha=0.15, color="gold")
+    axes[0,0].set_title("Fitness"); axes[0,0].legend(fontsize=8)
+    axes[0,0].axhline(0, color="white", lw=0.5, alpha=0.4)
+
+    axes[0,1].plot(gens, gdi,     color="violet",    lw=2, label="GDI composite")
+    axes[0,1].plot(gens, b_div,   color="cyan",      lw=1, label="behavior_div")
+    axes[0,1].plot(gens, lin_ent, color="lime",      lw=1, ls="--", label="lineage entropy")
+    axes[0,1].set_title("Genetic Diversity Index"); axes[0,1].legend(fontsize=8)
+
+    axes[0,2].plot(gens, w_div, color="orange", lw=1.5, label="weight_div")
+    axes[0,2].set_title("Weight Diversity"); axes[0,2].legend(fontsize=8)
+
+    axes[1,0].plot(gens, wpred, color="tomato", lw=1.5, label="world pred loss")
+    axes[1,0].set_title("JEPA World Predictor Loss"); axes[1,0].legend(fontsize=8)
+
+    axes[1,1].plot(gens, sig_rel, color="deepskyblue", lw=1.5, label="signal reliability")
+    axes[1,1].set_title("Signal Reliability"); axes[1,1].legend(fontsize=8)
+    axes[1,1].set_ylim(0, 1.05)
+
+    env_vol = [r.get("env_volatility", 0) for r in records]
+    noise   = [r.get("noise_strength", 0) for r in records]
+    axes[1,2].plot(gens, env_vol, color="salmon",      lw=1.5, label="env volatility")
+    axes[1,2].plot(gens, noise,   color="plum",        lw=1.5, ls="--", label="noise strength")
+    axes[1,2].set_title("Curriculum Schedule"); axes[1,2].legend(fontsize=8)
+
+    for ax in axes.flat:
+        ax.set_xlabel("generation", fontsize=8)
+        ax.grid(True, alpha=0.15)
+
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    out = str(OUT / "viz-training-progress.png")
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"    -> {out}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GIF 5: Phase-1 evaluation comparison bar chart
+# ---------------------------------------------------------------------------
+
+def viz_phase1_eval():
+    print("  [5/5] phase-1 evaluation bar chart...")
+    eval_path = OUT / "phase1-eval.json"
+    if not eval_path.exists():
+        print("    SKIP — eval file not found")
+        return None
+
+    records = json.loads(eval_path.read_text())
+    names   = [Path(r["checkpoint"]).stem for r in records]
+    # Shorten names
+    names   = [n.replace("model-core-", "").replace("coevo-guardrail-", "")
+                .replace("shared-extreme-", "se-").replace("champion-", "v")
+                .replace("transfercal-", "tc-") for n in names]
+
+    worlds  = ["legacy_20x20x10", "base_40x40x20", "new_env_v1"]
+    colors  = ["#4a90d9", "#7bc87a", "#e67e22"]
+    labels  = ["Legacy 20×20×10", "Base 40×40×20", "new_env_v1"]
+
+    x = range(len(names))
+    w = 0.25
+    fig, ax = plt.subplots(figsize=(12, 5))
+    for i, (world, col, lbl) in enumerate(zip(worlds, colors, labels)):
+        vals = [r.get(world, 0) for r in records]
+        offset = (i - 1) * w
+        bars = ax.bar([xi + offset for xi in x], vals, width=w, color=col, label=lbl, alpha=0.85)
+
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(names, rotation=25, ha="right", fontsize=9)
+    ax.axhline(0, color="white", lw=0.8, alpha=0.5)
+    ax.set_ylabel("Fitness")
+    ax.set_title("Phase-1 Cross-World Evaluation — Top 5 Champions", fontsize=12)
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.15, axis="y")
+    fig.tight_layout()
+    out = str(OUT / "viz-phase1-eval.png")
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"    -> {out}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    torch.manual_seed(SEED)
+
+    print("Loading models...")
+    champ_model,  champ_cfg  = load_model("artifacts/new-env-evolution/champion-new-env-v1.pt")
+    legacy_model, legacy_cfg = load_model("artifacts/model-core-champion-v08.pt")
+
+    wcfg_new = world_config_for_profile("new_env_v1")
+    world_new = make_world(wcfg_new)
+
+    print("\nGenerating visualizations...")
+    viz_champion_storm(champ_model, champ_cfg, wcfg_new, world_new)
+    viz_compare(champ_model, champ_cfg, legacy_model, legacy_cfg, wcfg_new, world_new)
+    viz_hazard_sweep(champ_model, champ_cfg, wcfg_new, world_new)
+    viz_training_progress()
+    viz_phase1_eval()
+
+    print("\nAll visualizations saved to", OUT)

--- a/scripts/viz_new_env.py
+++ b/scripts/viz_new_env.py
@@ -43,7 +43,7 @@ from ai_embedded_dynamic_diversity.sim.viz_cli import (
 OUT = Path("artifacts/new-env-evolution")
 OUT.mkdir(parents=True, exist_ok=True)
 
-DEVICE = torch.device("cuda")
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 STEPS = 120
 REMAP_EVERY = 18
 SEED = 42

--- a/skills/dynamic-diversity-research/references/session-lessons-latest.md
+++ b/skills/dynamic-diversity-research/references/session-lessons-latest.md
@@ -18,11 +18,12 @@ Date: 2026-03-01
 12. **Capability guardrail controls implemented** in coevolution selection with floor-based penalties and per-generation proxy telemetry (`mean_signal_reliability`, `mean_conjoining_gain`).
 13. **Guardrail retrain results (`v04`, `v05`)** improved capability over `v02` but reduced transfer enough to keep overall ranking below `v02`.
 14. **Training-vs-eval proxy gap remains:** high in-training signal proxy values did not translate to champion-level cross-eval capability, indicating calibration mismatch in guardrail proxies.
+15. **Transfer-calibrated `v06` is a net step forward:** rank improved above `v02` in calibrated cross-eval while keeping recovered capability, but still below champion line.
 
 ## Immediate Handoff Continuation
 
-1. Calibrate guardrail proxies against cross-eval capability metrics and update penalty formulation so in-training signals better predict final ranking.
-2. Rebalance transfer and capability objectives (starting from `v05`) to regain weighted transfer while preserving improved capability floor.
+1. Continue from `v06`: close the remaining gap to `v07/v09` by improving transfer on `car` and `hexapod` while holding capability gains.
+2. Calibrate guardrail proxies against cross-eval capability metrics and update penalty formulation so in-training signals better predict final ranking.
 3. Keep targeted curriculum pressure on `latency-storm` and `storm` for `hexapod`, `car`, `drone` to reduce dominant regression scenarios seen in storyboard deltas.
 
 ## Reuse Tags
@@ -39,4 +40,5 @@ Date: 2026-03-01
 - `capability-guardrail-needed`
 - `storyboard-v07-v03-calib-large`
 - `guardrail-v04-v05`
+- `transfercal-v06`
 - `proxy-calibration-gap`

--- a/src/ai_embedded_dynamic_diversity/config.py
+++ b/src/ai_embedded_dynamic_diversity/config.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
 
 
 @dataclass
@@ -19,10 +20,29 @@ class ModelConfig:
 
 
 @dataclass
+class HazardZoneConfig:
+    """Configuration for a single environmental hazard zone."""
+    # Fractional centre position in [0,1] for each axis
+    cx: float = 0.5
+    cy: float = 0.5
+    cz: float = 0.5
+    # Fractional half-extents in [0,1] for each axis
+    rx: float = 0.1
+    ry: float = 0.1
+    rz: float = 0.5
+    kind: str = "light_triggered"   # "light_triggered" | "airflow" | "periodic"
+    threshold: float = 0.5
+    shadow_safe: bool = True
+    # For "periodic" kind: period in steps
+    period: int = 16
+    hazard_weight: float = 0.4
+
+
+@dataclass
 class WorldConfig:
-    x: int = 20
-    y: int = 20
-    z: int = 10
+    x: int = 40
+    y: int = 40
+    z: int = 20
     resource_channels: int = 5
     decay: float = 0.03
     actuation_delay_steps: int = 0
@@ -31,6 +51,15 @@ class WorldConfig:
     sensor_dropout_burst_prob: float = 0.0
     surface_friction_scale: float = 1.0
     disturbance_correlation_horizon: int = 0
+    # Structural occlusion objects (T-shapes)
+    num_occlusion_objects: int = 0
+    occlusion_seed: int = 0
+    # Anonymous physics objects (push/pull/stack/bridge)
+    num_physics_objects: int = 0
+    phys_mass: float = 1.0
+    phys_friction: float = 0.85
+    # Environmental hazard zones
+    hazard_zones: List[HazardZoneConfig] = field(default_factory=list)
 
 
 @dataclass
@@ -71,13 +100,16 @@ def model_config_for_profile(profile: str) -> ModelConfig:
 
 def world_config_for_profile(profile: str) -> WorldConfig:
     normalized = profile.strip().lower()
-    if normalized in {"base", "default", "pi5", "edge", "train"}:
+    if normalized in {"base", "default", "train"}:
         return WorldConfig()
+    if normalized in {"pi5", "pi-5", "raspberry-pi-5", "edge"}:
+        # Memory-constrained: keep original 20×20×10
+        return WorldConfig(x=20, y=20, z=10)
     if normalized in {"large_v1", "large-v1"}:
         return WorldConfig(
-            x=28,
-            y=28,
-            z=14,
+            x=56,
+            y=56,
+            z=28,
             resource_channels=6,
             decay=0.025,
             actuation_delay_steps=1,
@@ -87,11 +119,38 @@ def world_config_for_profile(profile: str) -> WorldConfig:
             surface_friction_scale=0.85,
             disturbance_correlation_horizon=5,
         )
+    if normalized in {"new_env_v1", "new-env-v1"}:
+        return WorldConfig(
+            x=40,
+            y=40,
+            z=20,
+            resource_channels=6,
+            decay=0.028,
+            actuation_delay_steps=1,
+            actuation_noise_std=0.02,
+            sensor_latency_steps=1,
+            sensor_dropout_burst_prob=0.03,
+            surface_friction_scale=0.9,
+            disturbance_correlation_horizon=4,
+            num_occlusion_objects=3,
+            occlusion_seed=42,
+            num_physics_objects=3,
+            phys_mass=1.2,
+            phys_friction=0.82,
+            hazard_zones=[
+                HazardZoneConfig(cx=0.75, cy=0.25, cz=0.5, rx=0.08, ry=0.08, rz=0.5,
+                                 kind="light_triggered", threshold=0.45, shadow_safe=True, hazard_weight=0.35),
+                HazardZoneConfig(cx=0.25, cy=0.75, cz=0.5, rx=0.08, ry=0.08, rz=0.5,
+                                 kind="periodic", threshold=0.0, period=20, shadow_safe=False, hazard_weight=0.3),
+                HazardZoneConfig(cx=0.5, cy=0.5, cz=0.3, rx=0.06, ry=0.06, rz=0.3,
+                                 kind="airflow", threshold=0.4, shadow_safe=False, hazard_weight=0.25),
+            ],
+        )
     if normalized in {"large_v1_extreme", "large-v1-extreme"}:
         return WorldConfig(
-            x=32,
-            y=32,
-            z=16,
+            x=64,
+            y=64,
+            z=32,
             resource_channels=6,
             decay=0.022,
             actuation_delay_steps=2,

--- a/src/ai_embedded_dynamic_diversity/config.py
+++ b/src/ai_embedded_dynamic_diversity/config.py
@@ -40,9 +40,9 @@ class HazardZoneConfig:
 
 @dataclass
 class WorldConfig:
-    x: int = 40
-    y: int = 40
-    z: int = 20
+    x: int = 20
+    y: int = 20
+    z: int = 10
     resource_channels: int = 5
     decay: float = 0.03
     actuation_delay_steps: int = 0

--- a/src/ai_embedded_dynamic_diversity/models/world_predictor.py
+++ b/src/ai_embedded_dynamic_diversity/models/world_predictor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class LatentWorldPredictor(nn.Module):
+    """
+    JEPA-style latent world predictor (LeWM-inspired).
+
+    Learns f(z_t, a_t) → ẑ_{t+1} in latent space via a 2-layer MLP.
+    Trained with next-embedding MSE + SIGReg to prevent representational collapse.
+    Attached alongside ModelCore — no shared parameters.
+    """
+
+    def __init__(self, latent_dim: int, action_dim: int, hidden_dim: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(latent_dim + action_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, latent_dim),
+        )
+
+    def forward(self, z: torch.Tensor, a: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            z: current latent observation [B, latent_dim]
+            a: current action embedding [B, action_dim]
+        Returns:
+            predicted next latent [B, latent_dim]
+        """
+        return self.net(torch.cat([z, a], dim=-1))

--- a/src/ai_embedded_dynamic_diversity/models/world_predictor.py
+++ b/src/ai_embedded_dynamic_diversity/models/world_predictor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class LatentWorldPredictor(nn.Module):

--- a/src/ai_embedded_dynamic_diversity/sim/cli.py
+++ b/src/ai_embedded_dynamic_diversity/sim/cli.py
@@ -10,7 +10,7 @@ import typer
 from ai_embedded_dynamic_diversity.config import ModelConfig, WorldConfig, model_config_for_profile
 from ai_embedded_dynamic_diversity.models import ModelCore, UniversalConstructor, load_constructor_tape
 from ai_embedded_dynamic_diversity.sim.autopoiesis import autopoietic_metrics
-from ai_embedded_dynamic_diversity.sim.embodiments import embodiment_dof_table, device_map_for_embodiment, get_embodiment
+from ai_embedded_dynamic_diversity.sim.embodiments import embodiment_dof_table, device_map_for_embodiment, get_embodiment, dof_spatial_map
 from ai_embedded_dynamic_diversity.sim.world import DynamicDiversityWorld
 
 app = typer.Typer(add_completion=False)
@@ -113,6 +113,7 @@ def profile_embodiment_metrics(
 
     mapping_seed = seed + 37
     mapping = device_map_for_embodiment(cfg.io_channels, emb, device=dev, permutation_seed=mapping_seed)
+    spatial_map = dof_spatial_map(emb, world_z, world_y, world_x, dev)
 
     step_latency_ms: list[float] = []
     mismatch_values: list[float] = []
@@ -127,6 +128,8 @@ def profile_embodiment_metrics(
     remap_events = 0
     remap_steps: list[int] = []
     channel_usage_acc = torch.zeros(control_dim, device=dev)
+    channel_mismatch_acc = torch.zeros(control_dim, device=dev)
+    channel_firing_acc = torch.zeros(control_dim, device=dev)
     resource_values: list[float] = []
 
     if dev.type == "cuda":
@@ -153,7 +156,7 @@ def profile_embodiment_metrics(
             mismatch = torch.mean((applied - desired) ** 2)
             mismatch_values.append(float(mismatch.item()))
 
-            action_field = applied.mean(dim=1, keepdim=True).repeat(1, world_x * world_y * world_z)
+            action_field = applied @ spatial_map      # [batch, z*y*x] — DOF-spatially coupled
             state = world.step(state, action_field, controls=controls)
             vitality_values.append(float(state.life.mean().item()))
             stress_values.append(float(state.stress.mean().item()))
@@ -172,12 +175,17 @@ def profile_embodiment_metrics(
             memory_entropy_values.append(float(entropy.mean().item()))
 
             channel_usage_acc += torch.abs(applied).mean(dim=0)
+            per_dof_sq_err = ((applied - desired) ** 2).mean(dim=0)  # [control_dim]
+            channel_mismatch_acc += per_dof_sq_err
+            channel_firing_acc += (torch.abs(applied) > firing_threshold).float().mean(dim=0)
 
         if dev.type == "cuda":
             torch.cuda.synchronize(dev)
         step_latency_ms.append((time.perf_counter() - t0) * 1000.0)
 
     channel_usage = (channel_usage_acc / max(1, steps)).detach().cpu().tolist()
+    channel_mismatch = (channel_mismatch_acc / max(1, steps)).detach().cpu().tolist()
+    channel_firing = (channel_firing_acc / max(1, steps)).detach().cpu().tolist()
     low_count = min(8, len(channel_usage))
     low_usage_indices = sorted(range(len(channel_usage)), key=lambda i: channel_usage[i])[:low_count]
     high_usage_indices = sorted(range(len(channel_usage)), key=lambda i: channel_usage[i], reverse=True)[:low_count]
@@ -242,8 +250,24 @@ def profile_embodiment_metrics(
             **auto_metrics,
         },
         "io_profile": {
-            "low_usage_channels": [{"index": int(i), "usage": float(channel_usage[i])} for i in low_usage_indices],
-            "high_usage_channels": [{"index": int(i), "usage": float(channel_usage[i])} for i in high_usage_indices],
+            "per_dof": [
+                {
+                    "index": i,
+                    "dof_name": emb.controls[i] if i < len(emb.controls) else f"dof_{i:03d}",
+                    "usage": float(channel_usage[i]),
+                    "firing_frac": float(channel_firing[i]),
+                    "mismatch_contribution": float(channel_mismatch[i]),
+                }
+                for i in range(control_dim)
+            ],
+            "low_usage_dofs": [
+                {"index": int(i), "dof_name": emb.controls[i] if i < len(emb.controls) else f"dof_{i:03d}", "usage": float(channel_usage[i])}
+                for i in low_usage_indices
+            ],
+            "high_usage_dofs": [
+                {"index": int(i), "dof_name": emb.controls[i] if i < len(emb.controls) else f"dof_{i:03d}", "usage": float(channel_usage[i])}
+                for i in high_usage_indices
+            ],
         },
     }
 

--- a/src/ai_embedded_dynamic_diversity/sim/embodiments.py
+++ b/src/ai_embedded_dynamic_diversity/sim/embodiments.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
+from typing import Union
 
 import torch
 
@@ -127,6 +129,137 @@ def embodiment_dof_table() -> list[dict[str, int | str]]:
             }
         )
     return rows
+
+
+_DOF_ANATOMY: dict[str, list[tuple[float, float, float, float]]] = {
+    # (cz, cy, cx, sigma) per DOF, in the same order as Embodiment.controls
+    "hexapod": [
+        # leg_front_l, leg_front_r
+        (-0.7,  0.6, -0.5, 0.25), (-0.7,  0.6,  0.5, 0.25),
+        # leg_mid_l, leg_mid_r
+        (-0.7,  0.0, -0.6, 0.25), (-0.7,  0.0,  0.6, 0.25),
+        # leg_back_l, leg_back_r
+        (-0.7, -0.6, -0.5, 0.25), (-0.7, -0.6,  0.5, 0.25),
+        # arm_a, arm_b, arm_c, arm_d
+        ( 0.2,  0.3, -0.3, 0.30), ( 0.2,  0.3,  0.3, 0.30),
+        ( 0.2, -0.3, -0.3, 0.30), ( 0.2, -0.3,  0.3, 0.30),
+    ],
+    "car": [
+        # steer: lateral bias
+        (-0.5,  0.0,  0.0, 0.40),
+        # throttle: forward push
+        (-0.5,  0.5,  0.0, 0.35),
+        # brake: rearward
+        (-0.5, -0.5,  0.0, 0.35),
+        # gear: central
+        ( 0.0,  0.0,  0.0, 0.50),
+        # camera_gimbal: upper centre
+        ( 0.5,  0.0,  0.0, 0.40),
+        # suspension: full vertical column
+        ( 0.0,  0.0,  0.0, 0.80),
+    ],
+    "drone": [
+        # rotor_fl, rotor_fr, rotor_rl, rotor_rr
+        ( 0.6,  0.5, -0.5, 0.25), ( 0.6,  0.5,  0.5, 0.25),
+        ( 0.6, -0.5, -0.5, 0.25), ( 0.6, -0.5,  0.5, 0.25),
+        # pitch: forward tilt
+        ( 0.3,  0.4,  0.0, 0.35),
+        # roll: lateral tilt
+        ( 0.3,  0.0,  0.5, 0.35),
+        # yaw: rotation — broad
+        ( 0.5,  0.0,  0.0, 0.55),
+        # thrust: full z-column
+        ( 0.0,  0.0,  0.0, 0.85),
+    ],
+}
+
+
+def _anatomy_for_indexed(prefix_groups: list[tuple[str, int, float, float, float, float]]) -> list[tuple[float, float, float, float]]:
+    """Expand (prefix, count, cz, cy, cx, sigma) groups into per-DOF entries with slight jitter."""
+    entries = []
+    for prefix, count, cz, cy, cx, sigma in prefix_groups:
+        for k in range(count):
+            angle = 2.0 * math.pi * k / max(1, count)
+            r = sigma * 0.4
+            entries.append((
+                cz + r * math.sin(angle) * 0.3,
+                cy + r * math.cos(angle),
+                cx + r * math.sin(angle),
+                sigma,
+            ))
+    return entries
+
+
+_DOF_ANATOMY["polymorph120"] = _anatomy_for_indexed([
+    # locomotion_joint_000..047 — ground ring
+    ("locomotion_joint", 48, -0.7,  0.0,  0.0, 0.20),
+    # manipulator_joint_000..039 — mid-height reach
+    ("manipulator_joint", 40,  0.1,  0.0,  0.0, 0.22),
+    # spine_joint_000..015 — central z-axis
+    ("spine_joint",       16,  0.0,  0.0,  0.0, 0.18),
+    # thruster_000..015 — top hemisphere
+    ("thruster",          16,  0.7,  0.0,  0.0, 0.28),
+])
+
+_DOF_ANATOMY["humanoid120"] = _anatomy_for_indexed([
+    # humanoid_leg_joint_000..035 — lower body
+    ("humanoid_leg_joint",      36, -0.6,  0.0,  0.0, 0.22),
+    # humanoid_arm_joint_000..031 — lateral reach
+    ("humanoid_arm_joint",      32,  0.1,  0.0,  0.6, 0.22),
+    # humanoid_spine_joint_000..015 — vertical axis
+    ("humanoid_spine_joint",    16,  0.0,  0.0,  0.0, 0.18),
+    # humanoid_hand_joint_000..023 — distal reach
+    ("humanoid_hand_joint",     24,  0.0,  0.0,  0.8, 0.18),
+    # humanoid_neck_head_joint_000..011 — upper head
+    ("humanoid_neck_head_joint",12,  0.8,  0.0,  0.0, 0.20),
+])
+
+
+def dof_spatial_map(
+    embodiment: Union["Embodiment", str],
+    z: int,
+    y: int,
+    x: int,
+    device: Union[torch.device, str] = "cpu",
+) -> torch.Tensor:
+    """
+    Compute [control_dim, z*y*x] spatial influence tensor for an embodiment.
+
+    Each DOF gets a Gaussian blob at its anatomical position in normalised [-1,1]³.
+    Rows are L1-normalised so each DOF's total spatial influence sums to 1.
+    The map is deterministic and sits at the world boundary — anonymous to the model.
+    Falls back to uniform (equal weight per voxel) for DOFs with no anatomy entry.
+    """
+    if isinstance(embodiment, str):
+        embodiment = get_embodiment(embodiment)
+
+    dev = torch.device(device)
+    control_dim = len(embodiment.controls)
+    anatomy = _DOF_ANATOMY.get(embodiment.name.lower(), [])
+
+    # Build normalised coordinate grid [3, z*y*x]
+    zv = torch.linspace(-1.0, 1.0, z, device=dev)
+    yv = torch.linspace(-1.0, 1.0, y, device=dev)
+    xv = torch.linspace(-1.0, 1.0, x, device=dev)
+    gz, gy, gx = torch.meshgrid(zv, yv, xv, indexing="ij")
+    # Shape [z*y*x, 3]
+    coords = torch.stack([gz.flatten(), gy.flatten(), gx.flatten()], dim=1)
+
+    result = torch.zeros(control_dim, z * y * x, device=dev)
+    uniform = torch.ones(z * y * x, device=dev) / (z * y * x)
+
+    for i in range(control_dim):
+        if i < len(anatomy):
+            cz, cy, cx_val, sigma = anatomy[i]
+            centre = torch.tensor([[cz, cy, cx_val]], device=dev)
+            dist2 = ((coords - centre) ** 2).sum(dim=1)
+            blob = torch.exp(-dist2 / (sigma ** 2 + 1e-8))
+            total = blob.sum().clamp(min=1e-8)
+            result[i] = blob / total
+        else:
+            result[i] = uniform
+
+    return result  # [control_dim, z*y*x]
 
 
 def device_map_for_embodiment(

--- a/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
+++ b/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from ai_embedded_dynamic_diversity.models.core import ModelCore
+
+
+def _pairwise_cosine_distances(vecs: list[torch.Tensor]) -> float:
+    """Mean pairwise cosine distance (1 − similarity) for a list of 1-D vectors."""
+    n = len(vecs)
+    if n < 2:
+        return 0.0
+    stacked = torch.stack([v.float().flatten() for v in vecs], dim=0)  # [N, D]
+    norms = stacked.norm(dim=1, keepdim=True).clamp(min=1e-8)
+    normed = stacked / norms
+    sim_matrix = normed @ normed.t()  # [N, N]
+    total = 0.0
+    count = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            total += 1.0 - float(sim_matrix[i, j].item())
+            count += 1
+    return total / max(1, count)
+
+
+def _lineage_entropy(lineage: list[int]) -> float:
+    """Shannon entropy of parent index frequencies, normalised to [0,1]."""
+    if not lineage:
+        return 0.0
+    counts: dict[int, int] = {}
+    for p in lineage:
+        counts[p] = counts.get(p, 0) + 1
+    total = len(lineage)
+    entropy = 0.0
+    for c in counts.values():
+        p = c / total
+        if p > 0:
+            entropy -= p * math.log(p)
+    max_entropy = math.log(max(2, len(lineage)))
+    return entropy / max_entropy
+
+
+def _behavioral_species_count(io_traces: list[torch.Tensor], distance_threshold: float = 0.3) -> int:
+    """Single-linkage clustering count: number of clusters at given cosine distance threshold."""
+    n = len(io_traces)
+    if n == 0:
+        return 0
+    means = [t.float().mean(dim=0) if t.ndim > 1 else t.float() for t in io_traces]
+    # Union-find
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            vi = means[i].flatten()
+            vj = means[j].flatten()
+            ni = vi.norm().clamp(min=1e-8)
+            nj = vj.norm().clamp(min=1e-8)
+            cos_dist = 1.0 - float((vi / ni).dot(vj / nj).item())
+            if cos_dist < distance_threshold:
+                pi, pj = find(i), find(j)
+                if pi != pj:
+                    parent[pi] = pj
+    return len({find(i) for i in range(n)})
+
+
+def genetic_diversity_index(
+    population: list[ModelCore],
+    io_traces: list[torch.Tensor],
+    lineage: list[int],
+) -> dict[str, float]:
+    """
+    Compute population-level genetic and behavioural diversity metrics.
+
+    Args:
+        population: list of ModelCore instances (one per agent).
+        io_traces:  list of Tensors [T, io_channels] — per-agent IO outputs over last episode.
+        lineage:    list of parent indices for each agent this generation (same length as population).
+
+    Returns:
+        Dict with keys: weight_div, behavior_div, lineage_entropy, species_count, species_frac, gdi
+    """
+    n = len(population)
+    if n == 0:
+        return {
+            "weight_div": 0.0,
+            "behavior_div": 0.0,
+            "lineage_entropy": 0.0,
+            "species_count": 0,
+            "species_frac": 0.0,
+            "gdi": 0.0,
+        }
+
+    # Weight diversity: mean pairwise cosine distance of flattened param vectors
+    param_vecs: list[torch.Tensor] = []
+    for model in population:
+        with torch.no_grad():
+            flat = torch.cat([p.data.cpu().flatten() for p in model.parameters()])
+        param_vecs.append(flat)
+    weight_div = _pairwise_cosine_distances(param_vecs)
+
+    # Behavioural diversity: mean pairwise cosine distance of IO-trace means
+    behavior_div = 0.0
+    if io_traces:
+        behavior_div = _pairwise_cosine_distances(io_traces)
+
+    # Lineage entropy
+    lin_entropy = _lineage_entropy(lineage)
+
+    # Species count via single-linkage clustering
+    species = _behavioral_species_count(io_traces) if io_traces else 1
+    species_frac = species / max(1, n)
+
+    gdi = (
+        0.35 * weight_div
+        + 0.35 * behavior_div
+        + 0.20 * lin_entropy
+        + 0.10 * species_frac
+    )
+
+    return {
+        "weight_div": weight_div,
+        "behavior_div": behavior_div,
+        "lineage_entropy": lin_entropy,
+        "species_count": species,
+        "species_frac": species_frac,
+        "gdi": gdi,
+    }

--- a/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
+++ b/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
@@ -7,6 +7,7 @@ import torch
 
 if TYPE_CHECKING:
     from ai_embedded_dynamic_diversity.models.core import ModelCore
+    from ai_embedded_dynamic_diversity.sim.embodiments import Embodiment
 
 
 def _pairwise_cosine_distances(vecs: list[torch.Tensor]) -> float:
@@ -134,4 +135,86 @@ def genetic_diversity_index(
         "species_count": species,
         "species_frac": species_frac,
         "gdi": gdi,
+    }
+
+
+def dof_coordination_metrics(
+    io_traces: list[torch.Tensor],
+    io_channels: int,
+    activation_threshold: float = 0.05,
+) -> dict:
+    """
+    Population-level DOF coordination metrics computed from IO traces.
+
+    Args:
+        io_traces:   list of Tensors [T, io_channels] — one per agent.
+        io_channels: expected number of IO channels (for shape validation).
+        activation_threshold: minimum mean |activation| to count a channel as active.
+
+    Returns dict with:
+        per_channel_firing_rate  — [io_channels] mean |activation| across agents & time
+        channel_entropy          — Shannon entropy of per-channel mean activations (normalised)
+        co_activation_top5       — top-5 correlated channel pairs [(i, j, pearson_r)]
+        coverage_fraction        — fraction of channels exceeding activation_threshold
+    """
+    if not io_traces:
+        return {
+            "per_channel_firing_rate": [0.0] * io_channels,
+            "channel_entropy": 0.0,
+            "co_activation_top5": [],
+            "coverage_fraction": 0.0,
+        }
+
+    # Stack all traces: [N*T, io_channels]
+    stacked = torch.cat(
+        [t.float() if t.ndim == 2 else t.float().unsqueeze(0) for t in io_traces],
+        dim=0,
+    )
+    if stacked.shape[1] != io_channels:
+        # Truncate or pad to expected channels
+        if stacked.shape[1] > io_channels:
+            stacked = stacked[:, :io_channels]
+        else:
+            pad = torch.zeros(stacked.shape[0], io_channels - stacked.shape[1], device=stacked.device)
+            stacked = torch.cat([stacked, pad], dim=1)
+
+    per_channel = stacked.abs().mean(dim=0)  # [io_channels]
+    per_channel_list = per_channel.tolist()
+
+    # Shannon entropy of normalised per-channel activations
+    total = per_channel.sum().clamp(min=1e-8)
+    probs = per_channel / total
+    entropy = float(-(probs * (probs + 1e-8).log()).sum().item())
+    max_entropy = math.log(max(2, io_channels))
+    channel_entropy = min(1.0, entropy / max_entropy)
+
+    # Coverage: fraction of channels active above threshold
+    coverage_fraction = float((per_channel > activation_threshold).float().mean().item())
+
+    # Top-5 Pearson correlations between channel pairs
+    if stacked.shape[0] > 1:
+        mean = stacked.mean(dim=0, keepdim=True)
+        centred = stacked - mean
+        std = centred.std(dim=0).clamp(min=1e-8)
+        normed = centred / std           # [N*T, io_channels]
+        cov = (normed.T @ normed) / max(1, stacked.shape[0] - 1)  # [C, C]
+        # Zero out diagonal
+        cov.fill_diagonal_(0.0)
+        flat = cov.flatten()
+        top_vals, top_idx = flat.abs().topk(min(5, flat.numel()))
+        pairs = []
+        C = io_channels
+        for val, idx in zip(top_vals.tolist(), top_idx.tolist()):
+            i, j = divmod(int(idx), C)
+            if i < j:
+                pairs.append((i, j, round(float(cov[i, j].item()), 4)))
+        co_activation_top5 = pairs[:5]
+    else:
+        co_activation_top5 = []
+
+    return {
+        "per_channel_firing_rate": [round(v, 5) for v in per_channel_list],
+        "channel_entropy": round(channel_entropy, 4),
+        "co_activation_top5": co_activation_top5,
+        "coverage_fraction": round(coverage_fraction, 4),
     }

--- a/src/ai_embedded_dynamic_diversity/sim/signaling.py
+++ b/src/ai_embedded_dynamic_diversity/sim/signaling.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import List
+
 import torch
+from ai_embedded_dynamic_diversity.config import HazardZoneConfig
 from ai_embedded_dynamic_diversity.sim.world import DynamicDiversityWorld, WorldState, EnvironmentControls
 
 class SignalingWorld(DynamicDiversityWorld):
     """Extends world with explicit signal injection for detection tasks."""
-    
+
     def __init__(
         self,
         x: int,
@@ -20,6 +23,12 @@ class SignalingWorld(DynamicDiversityWorld):
         sensor_dropout_burst_prob: float = 0.0,
         surface_friction_scale: float = 1.0,
         disturbance_correlation_horizon: int = 0,
+        num_occlusion_objects: int = 0,
+        occlusion_seed: int = 0,
+        num_physics_objects: int = 0,
+        phys_mass: float = 1.0,
+        phys_friction: float = 0.85,
+        hazard_zones: List[HazardZoneConfig] | None = None,
     ):
         super().__init__(
             x,
@@ -34,6 +43,12 @@ class SignalingWorld(DynamicDiversityWorld):
             sensor_dropout_burst_prob=sensor_dropout_burst_prob,
             surface_friction_scale=surface_friction_scale,
             disturbance_correlation_horizon=disturbance_correlation_horizon,
+            num_occlusion_objects=num_occlusion_objects,
+            occlusion_seed=occlusion_seed,
+            num_physics_objects=num_physics_objects,
+            phys_mass=phys_mass,
+            phys_friction=phys_friction,
+            hazard_zones=hazard_zones,
         )
         # Signal types: 0=none, 1=peer, 2=environment, 3=threat
         self.signal_types = 4

--- a/src/ai_embedded_dynamic_diversity/sim/viz_cli.py
+++ b/src/ai_embedded_dynamic_diversity/sim/viz_cli.py
@@ -164,6 +164,10 @@ def _clone_state(state: WorldState) -> WorldState:
         stress=state.stress.clone(),
         object_pos=state.object_pos.clone(),
         object_vel=state.object_vel.clone(),
+        occlusion_mask=state.occlusion_mask.clone(),
+        phys_pos=state.phys_pos.clone(),
+        phys_vel=state.phys_vel.clone(),
+        phys_height=state.phys_height.clone(),
     )
 
 

--- a/src/ai_embedded_dynamic_diversity/sim/viz_cli.py
+++ b/src/ai_embedded_dynamic_diversity/sim/viz_cli.py
@@ -12,6 +12,7 @@ from ai_embedded_dynamic_diversity.config import model_config_for_profile
 from ai_embedded_dynamic_diversity.models import ModelCore
 from ai_embedded_dynamic_diversity.sim.embodiments import device_map_for_embodiment, get_embodiment
 from ai_embedded_dynamic_diversity.sim.world import DynamicDiversityWorld, EnvironmentControls, WorldState
+from ai_embedded_dynamic_diversity.sim.embodiments import dof_spatial_map
 
 app = typer.Typer(add_completion=False)
 
@@ -188,6 +189,7 @@ def _simulate(
 
     embodiment = get_embodiment(embodiment_name)
     mapping = device_map_for_embodiment(cfg.io_channels, embodiment, device=device, permutation_seed=seed_offset)
+    spatial_map = dof_spatial_map(embodiment, world.z, world.y, world.x, device)
 
     life_frames = []
     mismatch_values = []
@@ -196,6 +198,7 @@ def _simulate(
     force_values = []
     remap_steps = []
     object_trajectories = []
+    io_frames = []
 
     for step in range(params.steps):
         remap_code = torch.zeros(1, cfg.max_remap_groups, device=device)
@@ -214,7 +217,7 @@ def _simulate(
             applied = out["io"] @ mapping
             mismatch_values.append(float(torch.mean((applied - desired) ** 2).item()))
 
-            action = applied.mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+            action = applied @ spatial_map             # [1, z*y*x] — DOF-spatially coupled
             state = world.step(state, action, controls=controls)
             vitality_values.append(float(state.life.mean().item()))
             wind_values.append(float(torch.norm(controls.wind, dim=1).mean().item()))
@@ -223,6 +226,7 @@ def _simulate(
 
             frame = state.life[0, 0, world.z // 2].detach().cpu().numpy()
             life_frames.append(frame)
+            io_frames.append(out["io"].detach().cpu().mean(dim=0).numpy())
 
     return {
         "life_frames": life_frames,
@@ -232,6 +236,7 @@ def _simulate(
         "force_values": force_values,
         "remap_steps": remap_steps,
         "object_pos": object_trajectories,
+        "io_frames": io_frames,
     }
 
 
@@ -362,13 +367,24 @@ def _save_single(output: str, result: dict, title: str) -> None:
     line_force, = ax_env.plot([], [], color="tab:orange", label="force strength")
     ax_env.legend(loc="upper right")
 
-    # Task 3: Trajectory Overlay
-    ax_obj.set_title("Object Trajectory (X-Y)")
-    ax_obj.set_xlim(-1.1, 1.1)
-    ax_obj.set_ylim(-1.1, 1.1)
-    ax_obj.grid(True, alpha=0.3)
-    line_traj, = ax_obj.plot([], [], color="magenta", lw=1.5, label="path")
-    point_obj, = ax_obj.plot([], [], "o", color="red")
+    # Panel 4: IO channel activity heatmap (channels × steps)
+    ax_obj.set_title("IO Channel Activity")
+    ax_obj.set_xlabel("step")
+    ax_obj.set_ylabel("channel")
+    import numpy as _np
+    io_matrix = _np.zeros((1, 1))  # placeholder; filled on first update
+    if result.get("io_frames"):
+        io_matrix = _np.stack(result["io_frames"], axis=1)  # [io_channels, T]
+    io_heat = ax_obj.imshow(
+        io_matrix[:, :1],
+        aspect="auto",
+        cmap="RdBu_r",
+        vmin=-1.0,
+        vmax=1.0,
+        interpolation="nearest",
+    )
+    for rs in result["remap_steps"]:
+        ax_obj.axvline(rs, color="yellow", alpha=0.4, lw=0.8)
 
     fig.suptitle(title)
 
@@ -378,9 +394,9 @@ def _save_single(output: str, result: dict, title: str) -> None:
         line_vitality.set_data([], [])
         line_wind.set_data([], [])
         line_force.set_data([], [])
-        line_traj.set_data([], [])
-        point_obj.set_data([], [])
-        return (heat, line_mismatch, line_vitality, line_wind, line_force, line_traj, point_obj)
+        if result.get("io_frames"):
+            io_heat.set_data(io_matrix[:, :1])
+        return (heat, line_mismatch, line_vitality, line_wind, line_force, io_heat)
 
     def _update(i: int):
         xs = list(range(i + 1))
@@ -389,15 +405,10 @@ def _save_single(output: str, result: dict, title: str) -> None:
         line_vitality.set_data(xs, result["vitality_values"][: i + 1])
         line_wind.set_data(xs, result["wind_values"][: i + 1])
         line_force.set_data(xs, result["force_values"][: i + 1])
-        
-        if result["object_pos"]:
-            path_xy = result["object_pos"][: i + 1]
-            px = [p[0] for p in path_xy]
-            py = [p[1] for p in path_xy]
-            line_traj.set_data(px, py)
-            point_obj.set_data([px[-1]], [py[-1]])
-            
-        return (heat, line_mismatch, line_vitality, line_wind, line_force, line_traj, point_obj)
+        if result.get("io_frames") and i > 0:
+            io_heat.set_data(io_matrix[:, : i + 1])
+            io_heat.set_extent([0, i + 1, io_matrix.shape[0], 0])
+        return (heat, line_mismatch, line_vitality, line_wind, line_force, io_heat)
 
     anim = animation.FuncAnimation(fig, _update, init_func=_init, frames=len(result["life_frames"]), interval=70, blit=True)
 

--- a/src/ai_embedded_dynamic_diversity/sim/world.py
+++ b/src/ai_embedded_dynamic_diversity/sim/world.py
@@ -30,20 +30,41 @@ class WorldState:
         stress: torch.Tensor,
         object_pos: torch.Tensor,
         object_vel: torch.Tensor,
-        occlusion_mask: torch.Tensor,
-        phys_pos: torch.Tensor,
-        phys_vel: torch.Tensor,
-        phys_height: torch.Tensor,
+        occlusion_mask: torch.Tensor | None = None,
+        phys_pos: torch.Tensor | None = None,
+        phys_vel: torch.Tensor | None = None,
+        phys_height: torch.Tensor | None = None,
     ):
         self.life = life
         self.resources = resources
         self.stress = stress
         self.object_pos = object_pos
         self.object_vel = object_vel
-        self.occlusion_mask = occlusion_mask   # [B, 1, Z, Y, X] binary, permanent
-        self.phys_pos = phys_pos               # [B, N, 3] normalised [-1,1]
-        self.phys_vel = phys_vel               # [B, N, 3]
-        self.phys_height = phys_height         # [B, N, 1] stack height (≥1.0)
+
+        # Backward-compatible defaults for new fields
+        batch_size = life.size(0)
+        device = life.device
+        z, y, x = life.size(2), life.size(3), life.size(4)
+
+        if occlusion_mask is None:
+            self.occlusion_mask = torch.zeros(batch_size, 1, z, y, x, device=device)
+        else:
+            self.occlusion_mask = occlusion_mask
+
+        if phys_pos is None:
+            self.phys_pos = torch.zeros(batch_size, 0, 3, device=device)
+        else:
+            self.phys_pos = phys_pos
+
+        if phys_vel is None:
+            self.phys_vel = torch.zeros(batch_size, 0, 3, device=device)
+        else:
+            self.phys_vel = phys_vel
+
+        if phys_height is None:
+            self.phys_height = torch.zeros(batch_size, 0, 1, device=device)
+        else:
+            self.phys_height = phys_height
 
 
 class DynamicDiversityWorld:
@@ -372,6 +393,10 @@ class DynamicDiversityWorld:
     def step(self, state: WorldState, action_field: torch.Tensor, controls: EnvironmentControls | None = None) -> WorldState:
         if controls is None:
             controls = self.default_controls(action_field.size(0))
+
+        # Store the controls for use in encode_observation
+        self._prev_controls = controls
+
         if self.actuation_noise_std > 0.0:
             action_field = action_field + self.actuation_noise_std * torch.randn_like(action_field)
         if self.actuation_delay_steps > 0:
@@ -463,8 +488,15 @@ class DynamicDiversityWorld:
 
     def encode_observation(self, state: WorldState, signal_dim: int) -> torch.Tensor:
         # Aggregate anonymous signal channels; do not encode modality identity.
-        light_mean = self._light_field(self.default_controls(state.life.size(0))).mean(dim=(2, 3, 4))  # [B,1]
-        wind_mag = torch.zeros(state.life.size(0), 1, device=self.device)  # placeholder; populated from controls in step
+        # Use the last applied controls if available, otherwise fall back to defaults
+        if self._prev_controls is not None:
+            light_mean = self._light_field(self._prev_controls).mean(dim=(2, 3, 4))  # [B,1]
+            wind_mag = torch.norm(self._prev_controls.wind, dim=1, keepdim=True)  # [B,1]
+        else:
+            # Fallback for initial observation before first step
+            default_ctrl = self.default_controls(state.life.size(0))
+            light_mean = self._light_field(default_ctrl).mean(dim=(2, 3, 4))  # [B,1]
+            wind_mag = torch.zeros(state.life.size(0), 1, device=self.device)  # [B,1]
 
         # Hazard hint channels: pooled light field and step-phase sine
         step_phase = torch.full((state.life.size(0), 1), math.sin(2.0 * math.pi * self._step_index / 16.0), device=self.device)

--- a/src/ai_embedded_dynamic_diversity/sim/world.py
+++ b/src/ai_embedded_dynamic_diversity/sim/world.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
+from typing import List
 
 import torch
+import torch.nn.functional as F
+
+from ai_embedded_dynamic_diversity.config import HazardZoneConfig
 
 
 @dataclass
@@ -25,16 +30,24 @@ class WorldState:
         stress: torch.Tensor,
         object_pos: torch.Tensor,
         object_vel: torch.Tensor,
+        occlusion_mask: torch.Tensor,
+        phys_pos: torch.Tensor,
+        phys_vel: torch.Tensor,
+        phys_height: torch.Tensor,
     ):
         self.life = life
         self.resources = resources
         self.stress = stress
         self.object_pos = object_pos
         self.object_vel = object_vel
+        self.occlusion_mask = occlusion_mask   # [B, 1, Z, Y, X] binary, permanent
+        self.phys_pos = phys_pos               # [B, N, 3] normalised [-1,1]
+        self.phys_vel = phys_vel               # [B, N, 3]
+        self.phys_height = phys_height         # [B, N, 1] stack height (≥1.0)
 
 
 class DynamicDiversityWorld:
-    """3D cellular world with resources, stressors, and local flow constraints."""
+    """3D toroidal cellular world with occlusion, physics objects, and hazard zones."""
 
     def __init__(
         self,
@@ -50,6 +63,12 @@ class DynamicDiversityWorld:
         sensor_dropout_burst_prob: float = 0.0,
         surface_friction_scale: float = 1.0,
         disturbance_correlation_horizon: int = 0,
+        num_occlusion_objects: int = 0,
+        occlusion_seed: int = 0,
+        num_physics_objects: int = 0,
+        phys_mass: float = 1.0,
+        phys_friction: float = 0.85,
+        hazard_zones: List[HazardZoneConfig] | None = None,
     ):
         self.x = x
         self.y = y
@@ -65,10 +84,25 @@ class DynamicDiversityWorld:
         self.sensor_dropout_burst_prob = max(0.0, float(sensor_dropout_burst_prob))
         self.surface_friction_scale = max(0.0, float(surface_friction_scale))
         self.disturbance_correlation_horizon = max(0, int(disturbance_correlation_horizon))
+        self.num_occlusion_objects = max(0, int(num_occlusion_objects))
+        self.occlusion_seed = int(occlusion_seed)
+        self.num_physics_objects = max(0, int(num_physics_objects))
+        self.phys_mass = max(1e-3, float(phys_mass))
+        self.phys_friction = max(0.0, min(1.0, float(phys_friction)))
+        self.hazard_zones: List[HazardZoneConfig] = hazard_zones or []
         self._action_buffer: list[torch.Tensor] = []
         self._obs_buffer: list[torch.Tensor] = []
         self._dropout_burst_steps_remaining = 0
         self._prev_controls: EnvironmentControls | None = None
+        self._step_index: int = 0
+        # Pre-build hazard masks (spatial footprints, shape [1,Z,Y,X])
+        self._hazard_masks: list[torch.Tensor] = []
+        for hz in self.hazard_zones:
+            self._hazard_masks.append(self._build_hazard_mask(hz).to(self.device))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
 
     def _kernel3d(self) -> torch.Tensor:
         k = torch.ones((1, 1, 3, 3, 3), dtype=torch.float32)
@@ -80,7 +114,65 @@ class DynamicDiversityWorld:
         y = torch.linspace(-1.0, 1.0, self.y)
         x = torch.linspace(-1.0, 1.0, self.x)
         zz, yy, xx = torch.meshgrid(z, y, x, indexing="ij")
-        return torch.stack([xx, yy, zz], dim=0).unsqueeze(0)
+        return torch.stack([xx, yy, zz], dim=0).unsqueeze(0)  # [1,3,Z,Y,X]
+
+    def _build_hazard_mask(self, hz: HazardZoneConfig) -> torch.Tensor:
+        """Build a binary [1,Z,Y,X] mask for a hazard zone from fractional bounds."""
+        xc = int(hz.cx * self.x)
+        yc = int(hz.cy * self.y)
+        zc = int(hz.cz * self.z)
+        rx = max(1, int(hz.rx * self.x))
+        ry = max(1, int(hz.ry * self.y))
+        rz = max(1, int(hz.rz * self.z))
+        mask = torch.zeros(1, self.z, self.y, self.x)
+        z0, z1 = max(0, zc - rz), min(self.z, zc + rz)
+        y0, y1 = max(0, yc - ry), min(self.y, yc + ry)
+        x0, x1 = max(0, xc - rx), min(self.x, xc + rx)
+        mask[0, z0:z1, y0:y1, x0:x1] = 1.0
+        return mask
+
+    def _place_t_shapes(self, batch_size: int) -> torch.Tensor:
+        """Return binary occlusion mask [B,1,Z,Y,X] with T-shaped occlusion objects."""
+        mask = torch.zeros(batch_size, 1, self.z, self.y, self.x, device=self.device)
+        if self.num_occlusion_objects == 0:
+            return mask
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(self.occlusion_seed)
+        # Arm thickness: fixed 1 cell in Z, ~6% of Y/X dimensions
+        arm_thick_y = max(1, int(0.06 * self.y))
+        arm_thick_x = max(1, int(0.06 * self.x))
+        # Arm lengths: ~30% of Y/X
+        arm_len_y = max(2, int(0.30 * self.y))
+        arm_len_x = max(2, int(0.30 * self.x))
+        for _ in range(self.num_occlusion_objects):
+            cx = int(torch.randint(arm_len_x, self.x - arm_len_x, (1,), generator=gen).item())
+            cy = int(torch.randint(arm_len_y, self.y - arm_len_y, (1,), generator=gen).item())
+            cz = int(torch.randint(0, max(1, self.z // 2), (1,), generator=gen).item())
+            orient = int(torch.randint(0, 2, (1,), generator=gen).item())  # 0=horizontal stem, 1=vertical stem
+            # Stem (long bar)
+            if orient == 0:
+                # horizontal stem: extends in X
+                sx0, sx1 = max(0, cx - arm_len_x), min(self.x, cx + arm_len_x)
+                sy0, sy1 = max(0, cy - arm_thick_y), min(self.y, cy + arm_thick_y)
+            else:
+                # vertical stem: extends in Y
+                sx0, sx1 = max(0, cx - arm_thick_x), min(self.x, cx + arm_thick_x)
+                sy0, sy1 = max(0, cy - arm_len_y), min(self.y, cy + arm_len_y)
+            sz0, sz1 = cz, min(self.z, cz + max(1, self.z // 5))
+            mask[:, 0, sz0:sz1, sy0:sy1, sx0:sx1] = 1.0
+            # Crossbar (perpendicular arm at centre)
+            if orient == 0:
+                bx0, bx1 = max(0, cx - arm_thick_x), min(self.x, cx + arm_thick_x)
+                by0, by1 = max(0, cy - arm_len_y), min(self.y, cy + arm_len_y)
+            else:
+                bx0, bx1 = max(0, cx - arm_len_x), min(self.x, cx + arm_len_x)
+                by0, by1 = max(0, cy - arm_thick_y), min(self.y, cy + arm_thick_y)
+            mask[:, 0, sz0:sz1, by0:by1, bx0:bx1] = 1.0
+        return mask
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def default_controls(self, batch_size: int) -> EnvironmentControls:
         return EnvironmentControls(
@@ -132,11 +224,26 @@ class DynamicDiversityWorld:
         stress = torch.zeros(batch_size, 1, self.z, self.y, self.x, device=self.device)
         object_pos = torch.zeros(batch_size, 3, device=self.device)
         object_vel = torch.zeros(batch_size, 3, device=self.device)
+        occlusion_mask = self._place_t_shapes(batch_size)
+        # Physics objects: random positions in [-1,1], unit height
+        if self.num_physics_objects > 0:
+            phys_pos = torch.rand(batch_size, self.num_physics_objects, 3, device=self.device) * 2.0 - 1.0
+            phys_vel = torch.zeros(batch_size, self.num_physics_objects, 3, device=self.device)
+            phys_height = torch.ones(batch_size, self.num_physics_objects, 1, device=self.device)
+        else:
+            phys_pos = torch.zeros(batch_size, 0, 3, device=self.device)
+            phys_vel = torch.zeros(batch_size, 0, 3, device=self.device)
+            phys_height = torch.zeros(batch_size, 0, 1, device=self.device)
         self._action_buffer = []
         self._obs_buffer = []
         self._dropout_burst_steps_remaining = 0
         self._prev_controls = None
-        return WorldState(life, resources, stress, object_pos, object_vel)
+        self._step_index = 0
+        return WorldState(life, resources, stress, object_pos, object_vel, occlusion_mask, phys_pos, phys_vel, phys_height)
+
+    # ------------------------------------------------------------------
+    # Field computations
+    # ------------------------------------------------------------------
 
     def _light_field(self, controls: EnvironmentControls) -> torch.Tensor:
         pos = controls.light_position.view(-1, 3, 1, 1, 1)
@@ -155,13 +262,112 @@ class DynamicDiversityWorld:
     def _apply_wind_flow(self, resources: torch.Tensor, wind: torch.Tensor) -> torch.Tensor:
         flowed = resources
         shifts = torch.round(wind).to(torch.int64)
-        # Axis order in tensor is z, y, x.
         for b in range(resources.size(0)):
             dx = int(shifts[b, 0].item())
             dy = int(shifts[b, 1].item())
             dz = int(shifts[b, 2].item())
+            # torch.roll already wraps (toroidal), consistent with circular conv
             flowed[b : b + 1] = torch.roll(resources[b : b + 1], shifts=(dz, dy, dx), dims=(-3, -2, -1))
         return flowed
+
+    def _shadow_mask(self, light_field: torch.Tensor, occlusion_mask: torch.Tensor) -> torch.Tensor:
+        """Binary mask: 1 where cells are in shadow (low light AND near occlusion)."""
+        return ((light_field < 0.05).float() * occlusion_mask).clamp(0.0, 1.0)
+
+    def _compute_hazard_stress(
+        self,
+        light_field: torch.Tensor,
+        occlusion_mask: torch.Tensor,
+        wind: torch.Tensor,
+        step_index: int,
+    ) -> torch.Tensor:
+        """Aggregate hazard stress across all configured hazard zones."""
+        if not self.hazard_zones:
+            return torch.zeros_like(light_field)
+
+        shadow = self._shadow_mask(light_field, occlusion_mask)
+        wind_mag = torch.norm(wind, dim=1, keepdim=True).view(-1, 1, 1, 1, 1)
+        total = torch.zeros_like(light_field)
+
+        for hz, hz_mask in zip(self.hazard_zones, self._hazard_masks):
+            zone = hz_mask.to(light_field.device)  # [1,Z,Y,X]
+            if hz.kind == "light_triggered":
+                light_in_zone = (light_field * zone).mean(dim=(2, 3, 4), keepdim=True)
+                active = (light_in_zone > hz.threshold).float()
+                hazard_field = active * zone
+                if hz.shadow_safe:
+                    hazard_field = hazard_field * (1.0 - shadow)
+            elif hz.kind == "airflow":
+                active = (wind_mag > hz.threshold).float()
+                hazard_field = active * zone
+            elif hz.kind == "periodic":
+                phase = math.sin(2.0 * math.pi * step_index / max(1, hz.period))
+                active = 1.0 if phase > hz.threshold else 0.0
+                hazard_field = active * zone
+            else:
+                hazard_field = torch.zeros_like(light_field)
+
+            total = total + hz.hazard_weight * hazard_field
+
+        return total.clamp(0.0, 1.0)
+
+    def _physics_step(
+        self,
+        state: WorldState,
+        action_field: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Update physics object positions and velocities. Returns (phys_pos, phys_vel, phys_height)."""
+        if self.num_physics_objects == 0:
+            return state.phys_pos, state.phys_vel, state.phys_height
+
+        # Agent "centre" approximated as mean coord_grid weighted by action field amplitude
+        # Shape of action_field here: [B, 1, Z, Y, X]
+        af_abs = action_field.abs()
+        af_sum = af_abs.sum(dim=(2, 3, 4), keepdim=True).clamp(min=1e-6)
+        # coord_grid: [1,3,Z,Y,X] → weighted mean → [B,3]
+        agent_center = (self.coord_grid * af_abs / af_sum).sum(dim=(2, 3, 4))  # [B,3]
+
+        action_scalar = action_field.mean(dim=(1, 2, 3, 4))  # [B]
+
+        new_pos = state.phys_pos.clone()
+        new_vel = state.phys_vel.clone()
+        new_height = state.phys_height.clone()
+
+        for i in range(self.num_physics_objects):
+            obj_pos = state.phys_pos[:, i, :]   # [B,3]
+            obj_vel = state.phys_vel[:, i, :]   # [B,3]
+
+            disp = obj_pos - agent_center         # direction agent→object [B,3]
+            dist2 = (disp ** 2).sum(dim=1, keepdim=True).clamp(min=1e-6)  # [B,1]
+            prox = torch.exp(-dist2 / 0.08)       # [B,1]
+
+            # Push/pull: sign of action_scalar dot sign of disp determines direction
+            # Positive action + positive disp → push away; negative → pull toward
+            force_dir = disp / (dist2.sqrt() + 1e-6)  # unit vector [B,3]
+            force_mag = (action_scalar.unsqueeze(1) * prox) / self.phys_mass  # [B,1]
+            force = force_mag * force_dir  # [B,3]
+
+            obj_vel = self.phys_friction * obj_vel + force
+            obj_pos = (obj_pos + obj_vel).clamp(-1.0, 1.0)
+
+            new_vel[:, i, :] = obj_vel
+            new_pos[:, i, :] = obj_pos
+
+        # Stacking: if two objects are very close in XY, accumulate height
+        stack_threshold = 0.05
+        for i in range(self.num_physics_objects):
+            for j in range(i + 1, self.num_physics_objects):
+                xy_dist = (new_pos[:, i, :2] - new_pos[:, j, :2]).norm(dim=1)  # [B]
+                close = (xy_dist < stack_threshold).float().unsqueeze(1)  # [B,1]
+                new_height[:, i, :] = new_height[:, i, :] + close * 0.5
+                new_height[:, j, :] = new_height[:, j, :] + close * 0.5
+
+        new_height = new_height.clamp(1.0, float(self.z))
+        return new_pos, new_vel, new_height
+
+    # ------------------------------------------------------------------
+    # Main step
+    # ------------------------------------------------------------------
 
     def step(self, state: WorldState, action_field: torch.Tensor, controls: EnvironmentControls | None = None) -> WorldState:
         if controls is None:
@@ -176,33 +382,105 @@ class DynamicDiversityWorld:
                 delayed_action = self._action_buffer.pop(0)
             action_field = delayed_action
 
-        neighbors = torch.conv3d(state.life, self.kernel, padding=1)
+        # Toroidal convolution: circular padding removes hard walls
+        padded_life = F.pad(state.life, (1, 1, 1, 1, 1, 1), mode="circular")
+        neighbors = F.conv3d(padded_life, self.kernel, padding=0)
+
+        # Occlusion suppresses neighbour propagation across walls
+        if self.num_occlusion_objects > 0:
+            neighbors = neighbors * (1.0 - state.occlusion_mask)
+
         survive = ((neighbors >= 5) & (neighbors <= 7)).float() * state.life
         born = ((neighbors == 6).float()) * (1.0 - state.life)
 
-        action_field = action_field.view(action_field.size(0), 1, self.z, self.y, self.x)
+        action_field_vol = action_field.view(action_field.size(0), 1, self.z, self.y, self.x)
         light_boost = self._light_field(controls)
         force_impact = self._force_field(controls)
-        adaptive_bonus = torch.sigmoid(action_field + light_boost - 0.25 * force_impact) * (state.resources[:, :1] > 0.2).float()
+
+        # Occlusion attenuates resources
+        resource_occ_factor = 1.0 - 0.6 * state.occlusion_mask if self.num_occlusion_objects > 0 else 1.0
+
+        adaptive_bonus = torch.sigmoid(action_field_vol + light_boost - 0.25 * force_impact) * (state.resources[:, :1] > 0.2).float()
         new_life = torch.clamp(survive + born + 0.25 * adaptive_bonus - 0.1 * force_impact, 0.0, 1.0)
 
         resource_use = 0.05 * new_life
         flow = self._apply_wind_flow(state.resources, controls.wind) * 0.02
-        new_resources = torch.clamp(state.resources + flow + 0.03 * light_boost - resource_use - self.decay * state.resources, 0.0, 1.0)
+        new_resources = torch.clamp(
+            (state.resources + flow + 0.03 * light_boost - resource_use - self.decay * state.resources) * resource_occ_factor,
+            0.0,
+            1.0,
+        )
 
         pressure = (neighbors / 26.0).clamp(0.0, 1.0)
         scarcity = 1.0 - new_resources[:, :1]
         wind_pressure = torch.norm(controls.wind, dim=1, keepdim=True).view(-1, 1, 1, 1, 1)
-        new_stress = 0.55 * pressure + 0.35 * scarcity + 0.10 * wind_pressure + 0.2 * force_impact
+        hazard_stress = self._compute_hazard_stress(light_boost, state.occlusion_mask, controls.wind, self._step_index)
+
+        # Bridging: physics objects near hazard zones reduce local stress
+        bridge_reduction = torch.zeros_like(hazard_stress)
+        if self.num_physics_objects > 0 and self.hazard_zones:
+            for i in range(self.num_physics_objects):
+                obj_pos = state.phys_pos[:, i, :]     # [B,3]
+                obj_height = state.phys_height[:, i, :]  # [B,1]
+                # Project object position onto coord_grid distance
+                obj_xyz = obj_pos.view(-1, 3, 1, 1, 1)
+                obj_dist2 = ((self.coord_grid - obj_xyz) ** 2).sum(dim=1, keepdim=True)
+                span_factor = obj_height.view(-1, 1, 1, 1, 1) * 0.15
+                bridge_reduction = bridge_reduction + span_factor * torch.exp(-obj_dist2 / 0.06)
+            bridge_reduction = bridge_reduction.clamp(0.0, 0.5)
+
+        new_stress = (
+            0.55 * pressure
+            + 0.35 * scarcity
+            + 0.10 * wind_pressure
+            + 0.2 * force_impact
+            + hazard_stress
+            - bridge_reduction
+        ).clamp(0.0, 1.0)
 
         drag = max(0.0, min(1.0, 0.88 * self.surface_friction_scale))
         object_vel = drag * state.object_vel + controls.force_vector * controls.force_strength * controls.force_active
-        object_pos = state.object_pos + object_vel + controls.move_object_delta
-        object_pos = object_pos.clamp(-1.0, 1.0)
-        return WorldState(new_life, new_resources, new_stress.clamp(0.0, 1.0), object_pos, object_vel)
+        object_pos = (state.object_pos + object_vel + controls.move_object_delta).clamp(-1.0, 1.0)
+
+        new_phys_pos, new_phys_vel, new_phys_height = self._physics_step(state, action_field_vol)
+
+        self._step_index += 1
+        return WorldState(
+            new_life,
+            new_resources,
+            new_stress,
+            object_pos,
+            object_vel,
+            state.occlusion_mask,   # permanent — unchanged each step
+            new_phys_pos,
+            new_phys_vel,
+            new_phys_height,
+        )
+
+    # ------------------------------------------------------------------
+    # Observation encoding
+    # ------------------------------------------------------------------
 
     def encode_observation(self, state: WorldState, signal_dim: int) -> torch.Tensor:
         # Aggregate anonymous signal channels; do not encode modality identity.
+        light_mean = self._light_field(self.default_controls(state.life.size(0))).mean(dim=(2, 3, 4))  # [B,1]
+        wind_mag = torch.zeros(state.life.size(0), 1, device=self.device)  # placeholder; populated from controls in step
+
+        # Hazard hint channels: pooled light field and step-phase sine
+        step_phase = torch.full((state.life.size(0), 1), math.sin(2.0 * math.pi * self._step_index / 16.0), device=self.device)
+
+        # Physics object proximity channels (anonymous distances — no object ID)
+        if self.num_physics_objects > 0:
+            # Agent reference: origin (0,0,0) in normalised space
+            origin = torch.zeros(state.life.size(0), 3, device=self.device)
+            dists = []
+            for i in range(self.num_physics_objects):
+                d = (state.phys_pos[:, i, :] - origin).norm(dim=1, keepdim=True)  # [B,1]
+                dists.append(d)
+            phys_proximity = torch.cat(dists, dim=1)  # [B, N]
+        else:
+            phys_proximity = torch.zeros(state.life.size(0), 0, device=self.device)
+
         pooled = torch.cat(
             [
                 state.life.mean(dim=(2, 3, 4)),
@@ -210,6 +488,10 @@ class DynamicDiversityWorld:
                 state.stress.mean(dim=(2, 3, 4)),
                 state.object_pos,
                 state.object_vel,
+                light_mean,
+                wind_mag,
+                step_phase,
+                phys_proximity,
             ],
             dim=1,
         )

--- a/src/ai_embedded_dynamic_diversity/train/cli.py
+++ b/src/ai_embedded_dynamic_diversity/train/cli.py
@@ -1378,19 +1378,21 @@ def run(
             memory_persistence_loss_weight = new_weights["memory_persistence_loss_weight"]
             paging_loss_weight = new_weights["paging_loss_weight"]
 
-        # Collect IO traces for GDI and train world predictor (both optional overhead)
+        # Collect IO traces for GDI and diversity bonus only when needed
+        # This can be expensive (extra rollouts + diversity computation)
         io_traces: list[torch.Tensor] = []
-        for idx, model in enumerate(pop):
-            io_traces.append(
-                _collect_io_trace(
-                    model, world, mcfg, dev,
-                    steps=max(4, tcfg.unroll_steps // 2),
-                    batch=max(2, tcfg.batch_size // 4),
-                    env_volatility=env_volatility,
+        gdi_metrics = {"gdi": 0.0, "weight_div": 0.0, "behavior_div": 0.0, "lineage_entropy": 0.0, "species_count": 0}
+        if diversity_selection_bonus > 0.0:
+            for idx, model in enumerate(pop):
+                io_traces.append(
+                    _collect_io_trace(
+                        model, world, mcfg, dev,
+                        steps=max(4, tcfg.unroll_steps // 2),
+                        batch=max(2, tcfg.batch_size // 4),
+                        env_volatility=env_volatility,
+                    )
                 )
-            )
-
-        gdi_metrics = genetic_diversity_index(pop, io_traces, lineage_history)
+            gdi_metrics = genetic_diversity_index(pop, io_traces, lineage_history)
 
         mean_world_pred_loss = 0.0
         if coev_predictor is not None and coev_pred_opt is not None:
@@ -1434,18 +1436,23 @@ def run(
                     conjoining_gain_floor=conjoining_gain_floor,
                     penalty_weight=capability_guardrail_penalty_weight,
                 )
-            # Optional diversity bonus: reward agents that are behaviourally distant from elites
-            # Computed against best-yet IO trace (agent 0 in io_traces)
-            diversity_bonus = 0.0
-            if diversity_selection_bonus > 0.0 and len(io_traces) > 1:
-                ref = io_traces[0].float().mean(dim=0)
+            scores.append(raw_score - penalty)
+            score_penalties.append(penalty)
+
+        # Compute diversity bonus relative to current best agent (after scoring)
+        if diversity_selection_bonus > 0.0 and len(io_traces) > 1:
+            best_idx = max(range(len(scores)), key=lambda i: scores[i])
+            ref = io_traces[best_idx].float().mean(dim=0)
+            ref_n = ref.norm().clamp(min=1e-8)
+            for idx in range(len(pop)):
+                if idx == best_idx:
+                    continue  # No bonus for comparing to self
                 agent_trace = io_traces[idx].float().mean(dim=0)
-                ref_n = ref.norm().clamp(min=1e-8)
                 agent_n = agent_trace.norm().clamp(min=1e-8)
                 cos_dist = 1.0 - float(((ref / ref_n).dot(agent_trace / agent_n)).item())
                 diversity_bonus = diversity_selection_bonus * cos_dist
-            scores.append(raw_score - penalty + diversity_bonus)
-            score_penalties.append(penalty)
+                scores[idx] += diversity_bonus
+
         rank = sorted(range(len(pop)), key=lambda i: scores[i], reverse=True)
         elites = rank[:elite_count]
         best_idx = elites[0]

--- a/src/ai_embedded_dynamic_diversity/train/cli.py
+++ b/src/ai_embedded_dynamic_diversity/train/cli.py
@@ -14,13 +14,13 @@ from torch import nn
 
 from ai_embedded_dynamic_diversity.config import TrainConfig, WorldConfig, model_config_for_profile, world_config_for_profile
 from ai_embedded_dynamic_diversity.models import ModelCore, UniversalConstructor, load_constructor_tape
-from ai_embedded_dynamic_diversity.sim.embodiments import device_map_for_embodiment, get_embodiment
+from ai_embedded_dynamic_diversity.sim.embodiments import device_map_for_embodiment, get_embodiment, dof_spatial_map
 from ai_embedded_dynamic_diversity.sim.autopoiesis import autopoietic_metrics
 from ai_embedded_dynamic_diversity.sim.world import DynamicDiversityWorld
 from ai_embedded_dynamic_diversity.sim.signaling import SignalingWorld
-from ai_embedded_dynamic_diversity.sim.population_metrics import genetic_diversity_index
+from ai_embedded_dynamic_diversity.sim.population_metrics import genetic_diversity_index, dof_coordination_metrics
 from ai_embedded_dynamic_diversity.models.world_predictor import LatentWorldPredictor
-from ai_embedded_dynamic_diversity.train.losses import loss_fn, world_prediction_loss
+from ai_embedded_dynamic_diversity.train.losses import loss_fn, world_prediction_loss, io_differentiation_loss, dof_coverage_loss as _dof_coverage_loss
 from ai_embedded_dynamic_diversity.train.quantization import prepare_qat_model
 from ai_embedded_dynamic_diversity.models.memory_bank import GeneticMemoryBank
 from ai_embedded_dynamic_diversity.train.curriculum import AdaptiveLossController
@@ -271,6 +271,21 @@ def _capability_guardrail_penalty(
     return penalty_weight * (signal_deficit + conjoining_deficit)
 
 
+def _build_action_field(
+    io: torch.Tensor,
+    mapping: torch.Tensor,
+    world: "DynamicDiversityWorld",
+    spatial_map: torch.Tensor | None,
+) -> torch.Tensor:
+    """Build action field from IO output, using DOF spatial projection when available."""
+    applied = io.float() @ mapping          # [batch, control_dim]
+    if spatial_map is not None:
+        # spatial_map: [control_dim, z*y*x] — each DOF influences its anatomical region
+        return applied @ spatial_map        # [batch, z*y*x]
+    # Fallback: scalar broadcast
+    return applied.mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+
+
 @torch.no_grad()
 def _collect_io_trace(
     model: ModelCore,
@@ -372,7 +387,21 @@ def run_gradient_epoch(
     paging_loss_weight: float = 0.01,
     force_curriculum_mode: str = "none",
     force_curriculum_strength: float = 0.0,
+    io_diff_weight: float = 0.02,
+    dof_coverage_weight: float = 0.01,
+    primary_embodiment_name: str = "",
 ) -> tuple[float, torch.Tensor, float, float, float, float, float, float, float, float, float, float, float]:
+    # Resolve primary embodiment for DOF spatial coupling
+    _primary_emb_name = primary_embodiment_name
+    if not _primary_emb_name and transfer_states:
+        _primary_emb_name = next(iter(transfer_states))
+    _spatial_map: torch.Tensor | None = None
+    _primary_mapping: torch.Tensor | None = None
+    if _primary_emb_name:
+        _emb = get_embodiment(_primary_emb_name)
+        _spatial_map = dof_spatial_map(_emb, world.z, world.y, world.x, dev)
+        _primary_mapping = device_map_for_embodiment(mcfg.io_channels, _emb, device=dev, permutation_seed=42)
+
     state = world.init(tcfg.batch_size)
     if genetic_memory is None:
         memory = model.init_memory(tcfg.batch_size, mcfg.memory_slots, mcfg.memory_dim, dev)
@@ -430,6 +459,11 @@ def run_gradient_epoch(
                 ],
                 dim=1,
             )
+            _applied_for_loss = (
+                (out["io"].float() @ _primary_mapping).detach()
+                if _primary_mapping is not None
+                else None
+            )
             base_loss, logs = loss_fn(
                 out,
                 target,
@@ -444,6 +478,9 @@ def run_gradient_epoch(
                 memory_persistence_loss_weight=memory_persistence_loss_weight,
                 initial_memory=initial_memory_prior,
                 paging_loss_weight=paging_loss_weight,
+                io_diff_weight=io_diff_weight,
+                dof_coverage_weight=dof_coverage_weight,
+                applied_signal=_applied_for_loss,
             )
             remap_loss_total += logs["remap_loss"]
             detection_loss_total += logs["detection_loss"]
@@ -480,8 +517,12 @@ def run_gradient_epoch(
             
             transfer_mismatch_total += transfer_mismatch
 
-            # Apply actions to world
-            action_field = out["io"].detach().float().mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+            # Apply actions to world — use DOF spatial projection when available
+            action_field = _build_action_field(
+                out["io"].detach(), _primary_mapping if _primary_mapping is not None
+                else torch.ones(mcfg.io_channels, 1, device=dev) / mcfg.io_channels,
+                world, _spatial_map,
+            )
             controls = world.random_controls(tcfg.batch_size, volatility=env_volatility, step_index=step_index)
             _inject_force_curriculum_controls(
                 controls=controls,
@@ -565,7 +606,19 @@ def evaluate_fitness(
     genetic_memory_persistence_weight: float = 0.0,
     force_curriculum_mode: str = "none",
     force_curriculum_strength: float = 0.0,
+    primary_embodiment_name: str = "",
 ) -> float:
+    # Resolve DOF spatial coupling
+    _eval_emb_name = primary_embodiment_name
+    if not _eval_emb_name and transfer_states:
+        _eval_emb_name = next(iter(transfer_states))
+    _eval_spatial_map: torch.Tensor | None = None
+    _eval_mapping: torch.Tensor | None = None
+    if _eval_emb_name:
+        _eval_emb = get_embodiment(_eval_emb_name)
+        _eval_spatial_map = dof_spatial_map(_eval_emb, wcfg.z, wcfg.y, wcfg.x, dev)
+        _eval_mapping = device_map_for_embodiment(mcfg.io_channels, _eval_emb, device=dev, permutation_seed=42)
+
     model.eval()
     state = world.init(batch)
     memory = model.init_memory(batch, mcfg.memory_slots, mcfg.memory_dim, dev)
@@ -606,7 +659,12 @@ def evaluate_fitness(
                 remap_probability=0.3,
             )
             transfer_mismatch_total += transfer_mismatch
-        action_field = out["io"].float().mean(dim=1, keepdim=True).repeat(1, wcfg.x * wcfg.y * wcfg.z)
+        action_field = _build_action_field(
+            out["io"],
+            _eval_mapping if _eval_mapping is not None
+            else torch.ones(mcfg.io_channels, 1, device=dev) / mcfg.io_channels,
+            world, _eval_spatial_map,
+        )
         controls = world.random_controls(batch, env_volatility, step_index=step_index)
         _inject_force_curriculum_controls(
             controls=controls,
@@ -1391,6 +1449,7 @@ def run(
             )
 
         gdi_metrics = genetic_diversity_index(pop, io_traces, lineage_history)
+        dof_coord = dof_coordination_metrics(io_traces, mcfg.io_channels)
 
         mean_world_pred_loss = 0.0
         if coev_predictor is not None and coev_pred_opt is not None:
@@ -1464,6 +1523,8 @@ def run(
             "behavior_div": round(gdi_metrics["behavior_div"], 4),
             "lineage_entropy": round(gdi_metrics["lineage_entropy"], 4),
             "species_count": gdi_metrics["species_count"],
+            "dof_channel_entropy": round(dof_coord["channel_entropy"], 4),
+            "dof_coverage_frac": round(dof_coord["coverage_fraction"], 4),
             "mean_world_pred_loss": mean_world_pred_loss,
         })
         metrics_records.append(
@@ -1483,6 +1544,9 @@ def run(
                 "lineage_entropy": gdi_metrics["lineage_entropy"],
                 "species_count": gdi_metrics["species_count"],
                 "species_frac": gdi_metrics["species_frac"],
+                "dof_channel_entropy": dof_coord["channel_entropy"],
+                "dof_coverage_frac": dof_coord["coverage_fraction"],
+                "dof_co_activation_top5": dof_coord["co_activation_top5"],
                 "mean_world_pred_loss": mean_world_pred_loss,
                 "remap_probability": remap_probability,
                 "env_volatility": env_volatility,

--- a/src/ai_embedded_dynamic_diversity/train/cli.py
+++ b/src/ai_embedded_dynamic_diversity/train/cli.py
@@ -18,7 +18,9 @@ from ai_embedded_dynamic_diversity.sim.embodiments import device_map_for_embodim
 from ai_embedded_dynamic_diversity.sim.autopoiesis import autopoietic_metrics
 from ai_embedded_dynamic_diversity.sim.world import DynamicDiversityWorld
 from ai_embedded_dynamic_diversity.sim.signaling import SignalingWorld
-from ai_embedded_dynamic_diversity.train.losses import loss_fn
+from ai_embedded_dynamic_diversity.sim.population_metrics import genetic_diversity_index
+from ai_embedded_dynamic_diversity.models.world_predictor import LatentWorldPredictor
+from ai_embedded_dynamic_diversity.train.losses import loss_fn, world_prediction_loss
 from ai_embedded_dynamic_diversity.train.quantization import prepare_qat_model
 from ai_embedded_dynamic_diversity.models.memory_bank import GeneticMemoryBank
 from ai_embedded_dynamic_diversity.train.curriculum import AdaptiveLossController
@@ -267,6 +269,75 @@ def _capability_guardrail_penalty(
     signal_deficit = max(0.0, signal_reliability_floor - signal_reliability)
     conjoining_deficit = max(0.0, conjoining_gain_floor - conjoining_gain)
     return penalty_weight * (signal_deficit + conjoining_deficit)
+
+
+@torch.no_grad()
+def _collect_io_trace(
+    model: ModelCore,
+    world: DynamicDiversityWorld,
+    mcfg,
+    dev: torch.device,
+    steps: int = 8,
+    batch: int = 4,
+    env_volatility: float = 0.3,
+) -> torch.Tensor:
+    """Run a short rollout and return IO trace [T, io_channels] (batch-mean per step)."""
+    model.eval()
+    state = world.init(batch)
+    memory = model.init_memory(batch, mcfg.memory_slots, mcfg.memory_dim, dev)
+    traces: list[torch.Tensor] = []
+    for step_index in range(steps):
+        obs = world.encode_observation(state, signal_dim=mcfg.signal_dim)
+        remap = torch.zeros(batch, mcfg.max_remap_groups, device=dev)
+        out = model(obs, memory, remap)
+        memory = out["memory"]
+        traces.append(out["io"].detach().mean(dim=0))
+        action_field = out["io"].float().mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+        controls = world.random_controls(batch, env_volatility, step_index=step_index)
+        state = world.step(state, action_field, controls)
+    return torch.stack(traces, dim=0)  # [T, io_channels]
+
+
+def _train_world_predictor(
+    predictor: LatentWorldPredictor,
+    pred_opt: torch.optim.Optimizer,
+    model: ModelCore,
+    world: DynamicDiversityWorld,
+    mcfg,
+    tcfg: TrainConfig,
+    dev: torch.device,
+    env_volatility: float = 0.3,
+    steps: int = 8,
+    pred_loss_weight: float = 0.05,
+) -> float:
+    """Train the world predictor for one epoch; returns mean prediction loss."""
+    model.eval()
+    predictor.train()
+    state = world.init(tcfg.batch_size)
+    memory = model.init_memory(tcfg.batch_size, mcfg.memory_slots, mcfg.memory_dim, dev)
+    prev_obs: torch.Tensor | None = None
+    prev_action: torch.Tensor | None = None
+    pred_opt.zero_grad()
+    total_pred_loss = 0.0
+    for step_index in range(steps):
+        obs = world.encode_observation(state, signal_dim=mcfg.signal_dim)
+        remap = torch.zeros(tcfg.batch_size, mcfg.max_remap_groups, device=dev)
+        with torch.no_grad():
+            out = model(obs, memory, remap)
+            memory = out["memory"].detach()
+        if prev_obs is not None and prev_action is not None:
+            pred_latent = predictor(prev_obs, prev_action)
+            loss_val = world_prediction_loss(pred_latent, obs) * pred_loss_weight
+            loss_val.backward()
+            total_pred_loss += float(loss_val.item())
+        prev_obs = obs.detach()
+        prev_action = out["io"].detach()
+        action_field = out["io"].detach().float().mean(dim=1, keepdim=True).repeat(1, world.x * world.y * world.z)
+        controls = world.random_controls(tcfg.batch_size, env_volatility, step_index=step_index)
+        state = world.step(state, action_field, controls)
+    nn.utils.clip_grad_norm_(predictor.parameters(), 1.0)
+    pred_opt.step()
+    return total_pred_loss / max(1, steps - 1)
 
 
 def run_gradient_epoch(
@@ -689,6 +760,9 @@ def run(
     seed: int = 7,
     metrics_path: str = "",
     save_path: str = "artifacts/model-core.pt",
+    diversity_selection_bonus: float = 0.0,
+    enable_world_predictor: bool = False,
+    world_pred_loss_weight: float = 0.05,
 ) -> None:
     random.seed(seed)
     torch.manual_seed(seed)
@@ -764,6 +838,12 @@ def run(
         sensor_dropout_burst_prob=wcfg.sensor_dropout_burst_prob,
         surface_friction_scale=wcfg.surface_friction_scale,
         disturbance_correlation_horizon=wcfg.disturbance_correlation_horizon,
+        num_occlusion_objects=wcfg.num_occlusion_objects,
+        occlusion_seed=wcfg.occlusion_seed,
+        num_physics_objects=wcfg.num_physics_objects,
+        phys_mass=wcfg.phys_mass,
+        phys_friction=wcfg.phys_friction,
+        hazard_zones=wcfg.hazard_zones,
     )
     
     bank = None
@@ -847,6 +927,12 @@ def run(
         "memory_bank_path": memory_bank_path,
         "constructor_tape_path": constructor_tape_path,
         "constructor_tape_version": None if constructor_tape is None else constructor_tape.version,
+        "diversity_selection_bonus": diversity_selection_bonus,
+        "enable_world_predictor": enable_world_predictor,
+        "world_pred_loss_weight": world_pred_loss_weight,
+        "num_occlusion_objects": wcfg.num_occlusion_objects,
+        "num_physics_objects": wcfg.num_physics_objects,
+        "num_hazard_zones": len(wcfg.hazard_zones),
     }
 
     if not coevolution:
@@ -886,6 +972,13 @@ def run(
                 },
                 alpha=adaptive_loss_alpha
             )
+
+        predictor = None
+        pred_opt = None
+        if enable_world_predictor:
+            predictor = LatentWorldPredictor(mcfg.signal_dim, mcfg.io_channels).to(dev)
+            pred_opt = torch.optim.AdamW(predictor.parameters(), lr=tcfg.lr)
+            print({"info": "LatentWorldPredictor enabled"})
 
         for epoch in range(tcfg.epochs):
             if enable_curriculum:
@@ -976,6 +1069,14 @@ def run(
 
             if genetic_memory is not None:
                 genetic_memory = genetic_memory_decay * genetic_memory + (1.0 - genetic_memory_decay) * memory_snapshot
+            mean_world_pred_loss = 0.0
+            if predictor is not None and pred_opt is not None:
+                mean_world_pred_loss = _train_world_predictor(
+                    predictor, pred_opt, model, world, mcfg, tcfg, dev,
+                    env_volatility=env_volatility,
+                    steps=max(4, tcfg.unroll_steps // 2),
+                    pred_loss_weight=world_pred_loss_weight,
+                )
             fitness = evaluate_fitness(
                 model,
                 world,
@@ -1012,6 +1113,7 @@ def run(
                     "autopoietic_loss_component": mean_autopoietic_loss,
                     "mean_signal_reliability": mean_signal_reliability,
                     "mean_conjoining_gain": mean_conjoining_gain,
+                    "mean_world_pred_loss": mean_world_pred_loss,
                     "remap_probability": remap_probability,
                     "env_volatility": env_volatility,
                     "noise_strength": noise_strength,
@@ -1036,6 +1138,7 @@ def run(
                     "autopoietic_loss_component": mean_autopoietic_loss,
                     "mean_signal_reliability": mean_signal_reliability,
                     "mean_conjoining_gain": mean_conjoining_gain,
+                    "mean_world_pred_loss": mean_world_pred_loss,
                     "device": str(dev),
                     "profile": profile,
                     "remap_probability": remap_probability,
@@ -1129,6 +1232,15 @@ def run(
             },
             alpha=adaptive_loss_alpha
         )
+
+    coev_predictor = None
+    coev_pred_opt = None
+    if enable_world_predictor:
+        coev_predictor = LatentWorldPredictor(mcfg.signal_dim, mcfg.io_channels).to(dev)
+        coev_pred_opt = torch.optim.AdamW(coev_predictor.parameters(), lr=tcfg.lr)
+        print({"info": "LatentWorldPredictor enabled (coevolution)"})
+
+    lineage_history: list[int] = list(range(population_size))  # initial: each agent is its own parent
 
     elite_count = max(1, int(population_size * elite_fraction))
     for generation in range(tcfg.epochs):
@@ -1266,6 +1378,30 @@ def run(
             memory_persistence_loss_weight = new_weights["memory_persistence_loss_weight"]
             paging_loss_weight = new_weights["paging_loss_weight"]
 
+        # Collect IO traces for GDI and train world predictor (both optional overhead)
+        io_traces: list[torch.Tensor] = []
+        for idx, model in enumerate(pop):
+            io_traces.append(
+                _collect_io_trace(
+                    model, world, mcfg, dev,
+                    steps=max(4, tcfg.unroll_steps // 2),
+                    batch=max(2, tcfg.batch_size // 4),
+                    env_volatility=env_volatility,
+                )
+            )
+
+        gdi_metrics = genetic_diversity_index(pop, io_traces, lineage_history)
+
+        mean_world_pred_loss = 0.0
+        if coev_predictor is not None and coev_pred_opt is not None:
+            # Train shared predictor using agent 0 (representative; no extra fitness eval needed)
+            mean_world_pred_loss = _train_world_predictor(
+                coev_predictor, coev_pred_opt, pop[0], world, mcfg, tcfg, dev,
+                env_volatility=env_volatility,
+                steps=max(4, tcfg.unroll_steps // 2),
+                pred_loss_weight=world_pred_loss_weight,
+            )
+
         scores: list[float] = []
         score_penalties: list[float] = []
         for idx, model in enumerate(pop):
@@ -1298,21 +1434,37 @@ def run(
                     conjoining_gain_floor=conjoining_gain_floor,
                     penalty_weight=capability_guardrail_penalty_weight,
                 )
-            scores.append(raw_score - penalty)
+            # Optional diversity bonus: reward agents that are behaviourally distant from elites
+            # Computed against best-yet IO trace (agent 0 in io_traces)
+            diversity_bonus = 0.0
+            if diversity_selection_bonus > 0.0 and len(io_traces) > 1:
+                ref = io_traces[0].float().mean(dim=0)
+                agent_trace = io_traces[idx].float().mean(dim=0)
+                ref_n = ref.norm().clamp(min=1e-8)
+                agent_n = agent_trace.norm().clamp(min=1e-8)
+                cos_dist = 1.0 - float(((ref / ref_n).dot(agent_trace / agent_n)).item())
+                diversity_bonus = diversity_selection_bonus * cos_dist
+            scores.append(raw_score - penalty + diversity_bonus)
             score_penalties.append(penalty)
         rank = sorted(range(len(pop)), key=lambda i: scores[i], reverse=True)
         elites = rank[:elite_count]
         best_idx = elites[0]
         print({
-            "generation": generation + 1, 
-            "best_agent": best_idx, 
-            "best_fitness": scores[best_idx], 
+            "generation": generation + 1,
+            "best_agent": best_idx,
+            "best_fitness": scores[best_idx],
             "mean_fitness": sum(scores) / len(scores),
             "best_fitness_penalty": score_penalties[best_idx] if score_penalties else 0.0,
             "mean_signal_reliability": mean_signal_reliability_acc / max(1, len(pop)),
             "mean_conjoining_gain": mean_conjoining_gain_acc / max(1, len(pop)),
             "remap_loss_w": round(remap_loss_weight, 4),
             "detect_loss_w": round(detection_loss_weight, 4),
+            "gdi": round(gdi_metrics["gdi"], 4),
+            "weight_div": round(gdi_metrics["weight_div"], 4),
+            "behavior_div": round(gdi_metrics["behavior_div"], 4),
+            "lineage_entropy": round(gdi_metrics["lineage_entropy"], 4),
+            "species_count": gdi_metrics["species_count"],
+            "mean_world_pred_loss": mean_world_pred_loss,
         })
         metrics_records.append(
             {
@@ -1325,6 +1477,13 @@ def run(
                 "mean_transfer_mismatch": mean_transfer_mismatch_acc / max(1, len(pop)),
                 "mean_signal_reliability": mean_signal_reliability_acc / max(1, len(pop)),
                 "mean_conjoining_gain": mean_conjoining_gain_acc / max(1, len(pop)),
+                "gdi": gdi_metrics["gdi"],
+                "weight_div": gdi_metrics["weight_div"],
+                "behavior_div": gdi_metrics["behavior_div"],
+                "lineage_entropy": gdi_metrics["lineage_entropy"],
+                "species_count": gdi_metrics["species_count"],
+                "species_frac": gdi_metrics["species_frac"],
+                "mean_world_pred_loss": mean_world_pred_loss,
                 "remap_probability": remap_probability,
                 "env_volatility": env_volatility,
                 "noise_strength": noise_strength,
@@ -1336,12 +1495,15 @@ def run(
 
         next_pop = [copy.deepcopy(pop[i]).to(dev) for i in elites]
         next_transfer_states = [copy.deepcopy(transfer_states_by_agent[i]) for i in elites]
+        next_lineage: list[int] = list(elites)
         while len(next_pop) < population_size:
             parent_idx = random.choice(elites)
             parent = pop[parent_idx]
             child = mutate_from_parent(parent, mutation_std).to(dev)
             next_pop.append(child)
             next_transfer_states.append(copy.deepcopy(transfer_states_by_agent[parent_idx]))
+            next_lineage.append(parent_idx)
+        lineage_history = next_lineage
         pop = next_pop
         transfer_states_by_agent = next_transfer_states
         opts = [torch.optim.AdamW(model.parameters(), lr=tcfg.lr) for model in pop]

--- a/src/ai_embedded_dynamic_diversity/train/losses.py
+++ b/src/ai_embedded_dynamic_diversity/train/losses.py
@@ -5,6 +5,25 @@ import torch.nn.functional as F
 from torch import nn
 
 
+def io_differentiation_loss(io: torch.Tensor, margin: float = 0.15) -> torch.Tensor:
+    """Penalise near-uniform IO outputs across channels (channel collapse).
+
+    Computes per-sample std across io_channels and penalises when it falls
+    below `margin`. Zero gradient once std exceeds the margin.
+    """
+    channel_std = io.std(dim=1)                    # [batch]
+    return torch.relu(margin - channel_std).mean()
+
+
+def dof_coverage_loss(applied: torch.Tensor, threshold: float = 0.05) -> torch.Tensor:
+    """Penalise any control channel whose mean absolute activation is below threshold.
+
+    Ensures no DOF is permanently silent across the batch.
+    """
+    mean_activation = applied.abs().mean(dim=0)    # [control_dim]
+    return torch.relu(threshold - mean_activation).mean()
+
+
 def loss_fn(
     outputs: dict[str, torch.Tensor],
     target_signal: torch.Tensor,
@@ -19,6 +38,9 @@ def loss_fn(
     memory_persistence_loss_weight: float = 0.05,
     initial_memory: torch.Tensor | None = None,
     paging_loss_weight: float = 0.01,
+    io_diff_weight: float = 0.02,
+    dof_coverage_weight: float = 0.01,
+    applied_signal: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     io = outputs["io"]
     readiness = outputs["readiness"]
@@ -52,6 +74,16 @@ def loss_fn(
     # Paging loss: encourage using fewer memory slots per sample (L1 sparsity)
     paging_loss = torch.mean(torch.sum(torch.abs(memory_weights), dim=-1))
 
+    # IO channel differentiation: penalise near-uniform outputs across channels
+    io_diff = io_differentiation_loss(io) if io_diff_weight > 0.0 else io.new_zeros(())
+
+    # DOF coverage: penalise permanently-silent control channels
+    dof_cov = (
+        dof_coverage_loss(applied_signal)
+        if dof_coverage_weight > 0.0 and applied_signal is not None
+        else io.new_zeros(())
+    )
+
     time_consistency = torch.mean(torch.abs(outputs["memory"][:, 1:] - outputs["memory"][:, :-1]))
     total = (
         recon
@@ -63,6 +95,8 @@ def loss_fn(
         + emergent_signal_loss_weight * emergent_signal_loss
         + memory_persistence_loss_weight * memory_persistence_loss
         + paging_loss_weight * paging_loss
+        + io_diff_weight * io_diff
+        + dof_coverage_weight * dof_cov
     )
     logs = {
         "loss": total.item(),
@@ -75,6 +109,8 @@ def loss_fn(
         "emergent_signal_loss": emergent_signal_loss.item(),
         "memory_persistence_loss": memory_persistence_loss.item(),
         "paging_loss": paging_loss.item(),
+        "io_diff_loss": io_diff.item(),
+        "dof_coverage_loss": dof_cov.item(),
     }
     return total, logs
 

--- a/src/ai_embedded_dynamic_diversity/train/losses.py
+++ b/src/ai_embedded_dynamic_diversity/train/losses.py
@@ -97,6 +97,6 @@ def world_prediction_loss(
     """
     mse = F.mse_loss(pred_latent, actual_latent.detach())
     # SIGReg: penalise low variance across batch to prevent collapse
-    sigreg = sigreg_weight * torch.relu(1.0 - actual_latent.var(dim=0).mean())
+    sigreg = sigreg_weight * torch.relu(1.0 - pred_latent.var(dim=0).mean())
     return mse + sigreg
 

--- a/src/ai_embedded_dynamic_diversity/train/losses.py
+++ b/src/ai_embedded_dynamic_diversity/train/losses.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 
@@ -76,4 +77,26 @@ def loss_fn(
         "paging_loss": paging_loss.item(),
     }
     return total, logs
+
+
+def world_prediction_loss(
+    pred_latent: torch.Tensor,
+    actual_latent: torch.Tensor,
+    sigreg_weight: float = 0.1,
+) -> torch.Tensor:
+    """
+    JEPA-style world-prediction loss (LeWM-inspired).
+
+    MSE between predicted and actual next latent, plus SIGReg variance
+    regularisation to prevent representational collapse.
+
+    Args:
+        pred_latent:   predicted next-step latent [B, D]
+        actual_latent: actual next-step latent     [B, D]  (detached from model graph)
+        sigreg_weight: weight for variance regularisation term
+    """
+    mse = F.mse_loss(pred_latent, actual_latent.detach())
+    # SIGReg: penalise low variance across batch to prevent collapse
+    sigreg = sigreg_weight * torch.relu(1.0 - actual_latent.var(dim=0).mean())
+    return mse + sigreg
 


### PR DESCRIPTION
## Summary

Four interlocking additions that move the simulation from a flat, DOF-blind world to a spatially structured environment where articulation matters:

1. **Rich 40×40×20 Toroidal World** (`new_env_v1` profile): circular-padding convolution; T-shape occlusion objects; anonymous physics objects (push/pull/stack/bridge); 3 hazard zone kinds with temporal hint channels (light_triggered, airflow, periodic)
2. **DOF Spatial Coupling**: `dof_spatial_map()` routes each DOF to its anatomical world region — closes the causal loop between articulation and world effects
3. **Genetic Diversity Index (GDI)**: external population metric (weight_div, behavior_div, lineage_entropy, species_count) gated behind `diversity_selection_bonus > 0`
4. **JEPA Latent World Predictor**: `LatentWorldPredictor` + SIGReg; self-supervised; `--enable-world-predictor` flag
5. **Articulation differentiation losses**: `io_differentiation_loss` + `dof_coverage_loss` prevent channel collapse; per-DOF named profiling in `sim profiler`; IO activity heatmap in viz

## Checklist

- [x] All 9 Copilot review comments addressed (52be1d1: SIGReg gradient fix, WorldState backward compat, actual env controls in observation, GDI gating, diversity bonus relative to best agent)
- [x] Documentation updated: IMPLEMENTED.md (5 new entries), README.md (new profiles/flags), TODO.md (14 completed, 8 new)
- [x] 8 follow-up issues opened (#6–#13) for out-of-scope work
- [x] Champion evolved in new_env_v1: `artifacts/new-env-evolution/champion-new-env-v1.pt`
- [x] Visualizations committed: storm, compare, hazard sweep, training progress, phase-1 eval
- [x] Merge conflict in `train/cli.py` resolved: DOF spatial coupling + remote GDI fixes combined

## Issues closed by this PR

See issues #6–#13 for out-of-scope follow-on work tracked separately.

## Related artifacts

- `artifacts/new-env-evolution/champion-new-env-v1.pt` — new champion (pi5, multi-scale gating, world predictor)
- `artifacts/new-env-evolution/phase1-eval.json` — cross-world evaluation scores
- `artifacts/new-env-evolution/viz-*.gif` — storm, compare, hazard sweep visualizations