### PR TITLE
feat(metrics,env): per-embodiment GDI breakdown + hazard-aware signal injection

### DIFF
--- a/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
+++ b/src/ai_embedded_dynamic_diversity/sim/population_metrics.py
@@ -218,3 +218,68 @@ def dof_coordination_metrics(
         "co_activation_top5": co_activation_top5,
         "coverage_fraction": round(coverage_fraction, 4),
     }
+
+
+def embodiment_diversity_breakdown(
+    io_traces_by_embodiment: dict[str, list[torch.Tensor]],
+    activation_threshold: float = 0.05,
+) -> dict:
+    """
+    Per-embodiment behavioural diversity and cross-embodiment consistency.
+
+    Args:
+        io_traces_by_embodiment: dict mapping embodiment name → list of [T, io_channels]
+            tensors (one per agent).
+        activation_threshold: minimum mean |activation| to count a channel as active.
+
+    Returns dict with:
+        per_embodiment — {name: {"behavior_div": float, "coverage_fraction": float}}
+        cross_embodiment_consistency — mean cosine similarity of per-embodiment mean
+            vectors across the population (high = agent behaves similarly across
+            embodiments, low = specialised)
+    """
+    per_embodiment: dict[str, dict] = {}
+    emb_means: list[torch.Tensor] = []
+
+    for emb_name, traces in io_traces_by_embodiment.items():
+        if not traces:
+            per_embodiment[emb_name] = {"behavior_div": 0.0, "coverage_fraction": 0.0}
+            continue
+        behavior_div = _pairwise_cosine_distances(traces)
+        stacked = torch.cat([t.float() if t.ndim == 2 else t.float().unsqueeze(0) for t in traces], dim=0)
+        per_channel = stacked.abs().mean(dim=0)
+        coverage = float((per_channel > activation_threshold).float().mean().item())
+        per_embodiment[emb_name] = {"behavior_div": round(behavior_div, 4), "coverage_fraction": round(coverage, 4)}
+        # Population mean for this embodiment (mean across all agents × all steps)
+        emb_means.append(stacked.mean(dim=0))
+
+    # Cross-embodiment consistency: how similar are per-embodiment mean activation vectors?
+    cross_consistency = 0.0
+    if len(emb_means) >= 2:
+        n = len(emb_means)
+        total, count = 0.0, 0
+        for i in range(n):
+            for j in range(i + 1, n):
+                ni = emb_means[i].norm().clamp(min=1e-8)
+                nj = emb_means[j].norm().clamp(min=1e-8)
+                sim = float(((emb_means[i] / ni).dot(emb_means[j] / nj)).item())
+                total += sim
+                count += 1
+        cross_consistency = round(total / max(1, count), 4)
+
+    return {"per_embodiment": per_embodiment, "cross_embodiment_consistency": cross_consistency}
+
+
+def dof_coverage_per_embodiment(
+    io_traces_by_embodiment: dict[str, list[torch.Tensor]],
+    activation_threshold: float = 0.05,
+) -> dict[str, list[float]]:
+    """Mean |io| per channel grouped by embodiment. Returns {name: [firing_rate_per_channel]}."""
+    result: dict[str, list[float]] = {}
+    for emb_name, traces in io_traces_by_embodiment.items():
+        if not traces:
+            result[emb_name] = []
+            continue
+        stacked = torch.cat([t.float() if t.ndim == 2 else t.float().unsqueeze(0) for t in traces], dim=0)
+        result[emb_name] = [round(v, 5) for v in stacked.abs().mean(dim=0).tolist()]
+    return result

--- a/src/ai_embedded_dynamic_diversity/sim/signaling.py
+++ b/src/ai_embedded_dynamic_diversity/sim/signaling.py
@@ -52,13 +52,14 @@ class SignalingWorld(DynamicDiversityWorld):
         )
         # Signal types: 0=none, 1=peer, 2=environment, 3=threat
         self.signal_types = 4
-        # Threat agent position state (not in core WorldState yet, we'll manage it here for now)
-        self.threat_pos = None 
+        self.threat_pos = None
+        # Track which hazard zone kinds were active in the last step
+        self._active_hazard_kinds: set[str] = set()
 
     def init(self, batch_size: int) -> WorldState:
         state = super().init(batch_size)
-        # Initialize threat agent positions randomly at the edges
         self.threat_pos = torch.sign(torch.randn(batch_size, 3, device=self.device)) * 0.9
+        self._active_hazard_kinds = set()
         return state
 
     def step(self, state: WorldState, action_field: torch.Tensor, controls: EnvironmentControls) -> WorldState:
@@ -66,25 +67,42 @@ class SignalingWorld(DynamicDiversityWorld):
         if self.threat_pos is not None:
             direction = state.object_pos - self.threat_pos
             dist = torch.norm(direction, dim=1, keepdim=True).clamp_min(1e-6)
-            move = (direction / dist) * 0.05 # Speed
+            move = (direction / dist) * 0.05
             self.threat_pos = self.threat_pos + move
-            
-            # If threat agent is very close to object, it increases stress
             proximity = torch.norm(state.object_pos - self.threat_pos, dim=1)
             collision_mask = proximity < 0.15
             if collision_mask.any():
-                # Apply local stress at object position
-                # For simplicity, we just increase global stress component here
                 state.stress.add_(collision_mask.float().view(-1, 1, 1, 1, 1) * 0.1)
         
-        return super().step(state, action_field, controls)
+        new_state = super().step(state, action_field, controls)
+        # Infer which hazard kinds were active from the new stress field
+        self._active_hazard_kinds = set()
+        if self.hazard_zones:
+            for hz, hz_mask in zip(self.hazard_zones, self._hazard_masks):
+                zone_stress = (new_state.stress * hz_mask.to(new_state.stress.device)).mean()
+                if float(zone_stress.item()) > 0.05:
+                    self._active_hazard_kinds.add(hz.kind)
+        return new_state
 
-    def inject_signals(self, batch_size: int, p_peer: float = 0.1, p_env: float = 0.1, p_threat: float = 0.1) -> torch.Tensor:
-        """Generates a batch of signal labels and their anonymous representations."""
-        # labels: (B,)
+    def inject_signals(
+        self,
+        batch_size: int,
+        p_peer: float = 0.1,
+        p_env: float = 0.1,
+        p_threat: float = 0.1,
+        hazard_active_kinds: set[str] | None = None,
+    ) -> torch.Tensor:
+        """Generates signal labels, biased toward hazard-correlated types when hazards are active."""
+        # Bias probabilities based on active hazard kinds
+        active = hazard_active_kinds if hazard_active_kinds is not None else self._active_hazard_kinds
+        if "light_triggered" in active or "airflow" in active:
+            p_threat = min(0.4, p_threat * 1.5)
+        if "periodic" in active:
+            p_env = min(0.4, p_env * 1.5)
+
         labels = torch.zeros(batch_size, dtype=torch.long, device=self.device)
         r = torch.rand(batch_size, device=self.device)
-        
+
         peer_mask = r < p_peer
         env_mask = (r >= p_peer) & (r < p_peer + p_env)
         threat_mask = (r >= p_peer + p_env) & (r < p_peer + p_env + p_threat)


### PR DESCRIPTION
## Summary

**#10 — Per-embodiment GDI breakdown** (`sim/population_metrics.py`):
- `embodiment_diversity_breakdown()`: computes `behavior_div` and `coverage_fraction` per embodiment, plus `cross_embodiment_consistency` — measures whether the agent generalises uniformly across embodiments (high) or specialises per-embodiment (low)
- `dof_coverage_per_embodiment()`: per-embodiment channel firing rates `[io_channels]`

**#11 — Hazard-aware signal injection** (`sim/signaling.py`):
- `_active_hazard_kinds: set[str]` tracks which hazard zone kinds activated in the last step (inferred from stress field vs hazard masks)
- `inject_signals()` biases `p_threat ×1.5` when `light_triggered`/`airflow` hazards are active, `p_env ×1.5` when `periodic` is active — creates a learnable anonymous association between signal patterns and environmental danger

## Test plan
- [ ] `embodiment_diversity_breakdown({'hexapod': [...], 'car': [...]})` returns correct structure
- [ ] `SignalingWorld.step()` populates `_active_hazard_kinds` when hazards fire
- [ ] `inject_signals()` biases labels when `_active_hazard_kinds` is non-empty
- [ ] No regression on existing signaling tests

Closes #10, Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)