### PR TITLE
fix(viz): parse hyphenated storyboard scenarios

### DIFF
--- a/scripts/analyze_storyboard_metrics.py
+++ b/scripts/analyze_storyboard_metrics.py
@@ -24,6 +24,13 @@ def _load_metrics(path: Path) -> list[dict]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _split_scenario_embodiment(key: str) -> tuple[str, str]:
+    if "-" not in key:
+        return key, "unknown"
+    scenario, embodiment = key.rsplit("-", maxsplit=1)
+    return scenario, embodiment
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Summarize storyboard compare-left/compare-right metrics deltas.")
     parser.add_argument("--storyboard-dir", required=True, help="Directory containing *compare-left-metrics.json files.")
@@ -58,9 +65,7 @@ def main() -> int:
         l_vitality = [float(x.get("vitality", 0.0)) for x in left]
         r_vitality = [float(x.get("vitality", 0.0)) for x in right]
 
-        scen_emb = prefix.split("-", maxsplit=1)
-        scenario = scen_emb[0] if scen_emb else prefix
-        embodiment = scen_emb[1] if len(scen_emb) > 1 else "unknown"
+        scenario, embodiment = _split_scenario_embodiment(prefix)
 
         rows.append(
             {

--- a/tests/test_analyze_storyboard_metrics.py
+++ b/tests/test_analyze_storyboard_metrics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_analyzer():
+    script_path = Path("scripts/analyze_storyboard_metrics.py")
+    spec = importlib.util.spec_from_file_location("analyze_storyboard_metrics", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_split_scenario_embodiment_preserves_hyphenated_scenarios() -> None:
+    analyzer = _load_analyzer()
+
+    assert analyzer._split_scenario_embodiment("latency-storm-car") == ("latency-storm", "car")
+    assert analyzer._split_scenario_embodiment("storm-hexapod") == ("storm", "hexapod")
+    assert analyzer._split_scenario_embodiment("blackout") == ("blackout", "unknown")


### PR DESCRIPTION
## Summary
- Preserve hyphenated scenario names such as `latency-storm` when `scripts/analyze_storyboard_metrics.py` derives scenario/embodiment fields from storyboard metric keys.
- Add a regression test for `latency-storm-car` parsing.
- Verified the corrected analyzer maps the active regression targets to `latency-storm-{hexapod,drone,car}` and `storm-{car,hexapod,drone}`.

Refs #18

## Validation
- `.venv\Scripts\python.exe -m pytest -q tests\test_analyze_storyboard_metrics.py` -> `1 passed`
- `.venv\Scripts\python.exe scripts\analyze_storyboard_metrics.py --storyboard-dir artifacts\viz-storyboard-v07-v03-calib-large-v1 --left-tag model-core-champion-v07 --right-tag model-core-coevo-1200-shared-extreme-v03 --top-k 18 --output-json artifacts\viz-storyboard-v07-v03-calib-large-v1\compare-summary-corrected.json --output-md artifacts\viz-storyboard-v07-v03-calib-large-v1\compare-summary-corrected.md`

## Dynamic-Diversity Notes
Corrected top storm/latency targets from v07-vs-v03 storyboard audit:
- `latency-storm-hexapod`: mean mismatch delta `0.184093`, final `0.206351`
- `storm-car`: mean `0.108544`, final `0.177069`
- `latency-storm-drone`: mean `0.089545`, final `0.113358`
- `latency-storm-car`: mean `0.075294`, final `0.162591`
- `storm-hexapod`: mean `0.062700`, final `0.150853`
- `storm-drone`: mean `0.019301`, final `-0.003693`